### PR TITLE
Fix Spotify browse of empty objects and folders

### DIFF
--- a/plugins/music_service/spotify/index.js
+++ b/plugins/music_service/spotify/index.js
@@ -296,7 +296,7 @@ ControllerSpop.prototype.listPlaylists=function()
 	var commandDefer=self.sendSpopCommand('ls',[]);
 	commandDefer.then(function(results){
 			var resJson=JSON.parse(results);
-            //self.logger.info(JSON.stringify(resJson));
+                        self.logger.info(JSON.stringify(resJson));
 
 			self.commandRouter.logger.info(resJson);
 			var response={
@@ -310,15 +310,31 @@ ControllerSpop.prototype.listPlaylists=function()
 
 			for(var i in resJson.playlists)
 			{
-				if(resJson.playlists[i].name!=='')
+				if(resJson.playlists[i].hasOwnProperty('name') && resJson.playlists[i].name !== '')
 				{
-					response.navigation.list.push({
-						service: 'spop',
-						type: 'folder',
-						title: resJson.playlists[i].name,
-						icon: 'fa fa-list-ol',
-						uri: 'spotify/playlists/'+resJson.playlists[i].index
-					});
+					if(resJson.playlists[i].type == 'playlist')
+					{
+						response.navigation.list.push({
+							service: 'spop',
+							type: 'folder',
+							title: resJson.playlists[i].name,
+							icon: 'fa fa-list-ol',
+							uri: 'spotify/playlists/'+resJson.playlists[i].index
+					        });
+				        }
+					else if(resJson.playlists[i].type == 'folder')
+					{
+						for(var j in resJson.playlists[i].playlists)
+						{
+							response.navigation.list.push({
+							        service: 'spop',
+							        type: 'folder',
+							        title: resJson.playlists[i].playlists[j].name,
+							        icon: 'fa fa-list-ol',
+							        uri: 'spotify/playlists/'+resJson.playlists[i].playlists[j].index
+					                });
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes issues 514 and 507.  Check for empty objects in list of Spotify playlists from spop.  Explode playlists in folders instead of showing them as a playlist.  First attempt at contributing to Volumio 2, hope I didn't screw anything up!  Tested on my Raspberry Pi 3, although since this is an installable plugin, I had to copy over the changed file to the final destination instead of just having the changed file in place with Git.