### PR TITLE
Basic uninstall clean-up

### DIFF
--- a/plugins/miscellanea/touch_display/uninstall.sh
+++ b/plugins/miscellanea/touch_display/uninstall.sh
@@ -4,4 +4,9 @@ echo "Unistalling gpiobuttons dependencies"
 
 echo "Removing Touch display"
 
+sudo rm /opt/volumiokiosk.sh
+sudo rm /lib/systemd/system/volumio-kiosk.service
+sudo rm /etc/systemd/system/multi-user.target.wants/volumio-kiosk.service
+
 echo "Done"
+echo "pluginuninstallend"


### PR DESCRIPTION
Avoids kiosk starts even plugin is uninstalled.
Obviously, this would require fixing the following issue before, so that uninstall.sh is called.
https://github.com/volumio/Volumio2/issues/851

While at it, other plugin uninstall thingy that needs consideration:
https://github.com/volumio/Volumio2/issues/905 (not absolutely required for this specific one, but necessary too)