### PR TITLE
Hide mouse pointer

### DIFF
--- a/plugins/miscellanea/touch_display/install.sh
+++ b/plugins/miscellanea/touch_display/install.sh
@@ -68,7 +68,7 @@ xset 0 0 120
 openbox-session &
 while true; do
   /usr/bin/chromium-browser \\
-    --no-touch-pinch \\
+    --disable-pinch \\
     --kiosk \\
     --no-first-run \\
     --disable-3d-apis \\
@@ -92,7 +92,7 @@ After=volumio.service
 Type=simple
 User=root
 Group=root
-ExecStart=/usr/bin/startx /etc/X11/Xsession /opt/volumiokiosk.sh
+ExecStart=/usr/bin/startx /etc/X11/Xsession /opt/volumiokiosk.sh -- -nocursor
 # Give a reasonable amount of time for the server to start up/shut down
 TimeoutSec=300
 [Install]


### PR DESCRIPTION
1. Added the switch '-- -nocursor' to the ExecStart= line to hide the mouse pointer. Since this is touchscreen, there's really no point in having the cursor visible
2. Changed "--no-touch-pinch" to "--disable-pinch" since the former is deprecated.