### PR TITLE
add Samsung_BN59-006XXA remote

### DIFF
--- a/plugins/accessory/ir_controller/configurations/Samsung_BN59-006XXA/lircd.conf
+++ b/plugins/accessory/ir_controller/configurations/Samsung_BN59-006XXA/lircd.conf
@@ -1,0 +1,38 @@
+begin remote
+
+  name  lircd.conf
+  bits           16
+  flags SPACE_ENC|CONST_LENGTH
+  eps            30
+  aeps          100
+
+  header       4503  4433
+  one           597  1624
+  zero          597   514
+  ptrail        602
+  pre_data_bits  16
+  pre_data   0xE0E0
+  gap        107978
+  toggle_bit_mask 0x0
+
+      begin codes
+          KEY_PLAYPAUSE			0xE21D
+          KEY_STOP			0x629D
+	  KEY_REWIND			0xA25D
+          KEY_FORWARD			0x12ED
+          KEY_MUTE			0xF00F
+          KEY_VOLUMEUP			0xE01F
+          KEY_VOLUMEDOWN		0xD02F
+          KEY_POWER			0x40BF
+          KEY_PREVIOUSSONG		0x08F7
+          KEY_NEXTSONG			0x48B7
+          KEY_UP			0x06F9
+          KEY_RIGHT			0x46B9
+          KEY_DOWN			0x8679
+          KEY_LEFT			0xA659
+	  KEY_BACK			0x1AE5
+	  KEY_MENU			0x58A7
+	  KEY_ENTER			0x16E9
+      end codes
+
+end remote

--- a/plugins/accessory/ir_controller/configurations/Samsung_BN59-006XXA/lircrc
+++ b/plugins/accessory/ir_controller/configurations/Samsung_BN59-006XXA/lircrc
@@ -1,0 +1,90 @@
+begin
+prog = irexec
+button = KEY_ENTER
+config = /usr/local/bin/volumio toggle
+end
+
+begin
+prog = irexec
+button = KEY_PLAYPAUSE
+config = /usr/local/bin/volumio toggle
+end
+
+begin
+prog = irexec
+button = KEY_STOP
+config = /usr/local/bin/volumio stop
+end
+
+begin
+prog = irexec
+button = KEY_VOLUMEUP
+config = /usr/local/bin/volumio volume plus
+end
+
+begin
+prog = irexec
+button = KEY_VOLUMEDOWN
+config = /usr/local/bin/volumio volume minus
+end
+
+begin
+prog = irexec
+button = KEY_RIGHT
+config = /usr/local/bin/volumio next
+end
+
+begin
+prog = irexec
+button = KEY_NEXTSONG
+config = /usr/local/bin/volumio next
+end
+
+begin
+prog = irexec
+button = KEY_LEFT
+config = /usr/local/bin/volumio previous
+end
+
+begin
+prog = irexec
+button = KEY_PREVIOUSSONG
+config = /usr/local/bin/volumio previous
+end
+
+begin
+prog = irexec
+button = KEY_MUTE
+config = /usr/local/bin/volumio volume toggle
+repeat = 0
+end
+
+begin
+prog = irexec
+button = KEY_UP
+config = /usr/local/bin/volumio seek plus
+end
+
+begin
+prog = irexec
+button = KEY_DOWN
+config = /usr/local/bin/volumio seek minus
+end
+
+begin
+prog = irexec
+button = KEY_BACK
+config = /usr/local/bin/volumio repeat
+end
+
+begin
+prog = irexec
+button = KEY_MENU
+config = /usr/local/bin/volumio random
+end
+
+begin
+prog = irexec
+button = KEY_POWER
+config = shutdown -h now;sleep 1
+end


### PR DESCRIPTION
Hi,
I have created (and tested) a new lirc configuration for Samsung BN59-006XXA remotes. XX means I have two remotes BN59-00606A and BN59-00613A working.
Regards.