### PR TITLE
Enable repeated key presses and shutdown for ODroid remote

### DIFF
--- a/plugins/accessory/ir_controller/configurations/Odroid Remote/lircd.conf
+++ b/plugins/accessory/ir_controller/configurations/Odroid Remote/lircd.conf
@@ -1,33 +1,34 @@
 begin remote
 
-  name  lircd.conf
-  bits           16
-  flags SPACE_ENC|CONST_LENGTH
-  eps            30
-  aeps          100
+	name			odroid
+	bits			16
+	flags			SPACE_ENC|CONST_LENGTH
+	eps				30
+	aeps			100
 
-  header       8964  4507
-  one           544  1692
-  zero          544   561
-  ptrail        544
-  pre_data_bits   16
-  pre_data       0x4DB2
-  gap          107872
-  toggle_bit_mask 0x0
+	header			9000 4500
+	one				563 1688
+	zero			563 564
+	ptrail			563
+	pre_data_bits	16
+	pre_data		0x4DB2
+	repeat			9000 2250
+	gap				100000
+	toggle_bit_mask	0x0
 
-      begin codes
-          KEY_LEFT                 0x9966
-          KEY_RIGHT                0x837C
-          KEY_UP                   0x53AC
-          KEY_DOWN                 0x4BB4
-          KEY_ENTER                0x738C
-          KEY_HOME                 0x41BE
-          KEY_MUTE                 0x11EE
-          KEY_MENU                 0xA35C
-          KEY_BACK                 0x59A6
-          KEY_VOLUMEDOWN           0x817E
-          KEY_VOLUMEUP             0x01FE
-          KEY_POWER                0x3BC4
-      end codes
+	begin codes
+		KEY_LEFT		0x9966
+		KEY_RIGHT		0x837C
+		KEY_UP			0x53AC
+		KEY_DOWN		0x4BB4
+		KEY_ENTER		0x738C
+		KEY_HOME		0x41BE
+		KEY_MUTE		0x11EE
+		KEY_MENU		0xA35C
+		KEY_BACK		0x59A6
+		KEY_VOLUMEDOWN	0x817E
+		KEY_VOLUMEUP	0x01FE
+		KEY_POWER		0x3BC4
+	end codes
 
 end remote

--- a/plugins/accessory/ir_controller/configurations/Odroid Remote/lircrc
+++ b/plugins/accessory/ir_controller/configurations/Odroid Remote/lircrc
@@ -7,11 +7,15 @@ begin
 prog = irexec
 button = KEY_VOLUMEUP
 config = /usr/local/bin/volumio volume plus
+delay=2
+repeat=3
 end
 begin
 prog = irexec
 button = KEY_VOLUMEDOWN
 config = /usr/local/bin/volumio volume minus
+delay=2
+repeat=3
 end
 begin
 prog = irexec
@@ -27,17 +31,20 @@ begin
 prog = irexec
 button = KEY_MUTE
 config = /usr/local/bin/volumio volume toggle
-repeat = 0
 end
 begin
 prog = irexec
 button = KEY_UP
 config = /usr/local/bin/volumio seek plus
+delay=2
+repeat=3
 end
 begin
 prog = irexec
 button = KEY_DOWN
 config = /usr/local/bin/volumio seek minus
+delay=2
+repeat=3
 end
 begin
 prog = irexec
@@ -48,4 +55,9 @@ begin
 prog = irexec
 button = KEY_MENU
 config = /usr/local/bin/volumio random
+end
+begin
+prog = irexec
+button = KEY_POWER
+config = /sbin/shutdown -h now
 end


### PR DESCRIPTION
Currently, the ODroid remote configuration does not work for repeating signals, i.e. if the volume minus button is pushed for a longer time, the volume still only decreases on step. Also, the power button on the remote does not do anything.

Current situation:
The current lircd.conf for the ODroid remote was taken from:
https://wiki.odroid.com/odroid-c1/software/c1_lirc
Whereas ODroid / Hardkernel has also published two other versions of this config
https://wiki.odroid.com/odroid-c2/application_note/gpio/lirc_gpio_blaster
https://wiki.odroid.com/odroid-c2/application_note/lirc

The latter two are slightly different, and seem to be based on actual specifications, whereas the first seems to have been measured using lirc.

The old version of lircd.conf did not allow for repeat key presses. This pull request contains the lircd.conf from the second link, which enables repeating key presses (long press).
Repeating key presses have been implemented in lircrc for volume up/down and for seek forward/backward, i.e. holding these keys will now cause the volume or seek change to continue until the key is released.

I also implemented a shutdown function for the remote's power button.