### PR TITLE
Enabled Last.fm support for Spop

### DIFF
--- a/plugins/music_service/spotify/UIConfig.json
+++ b/plugins/music_service/spotify/UIConfig.json
@@ -14,6 +14,8 @@
         "data": [
           "username",
           "password",
+          "lastfmusername",
+          "lastfmpassword",
           "bitrate"
         ]
       },
@@ -32,6 +34,22 @@
           "element": "input",
           "doc": "This is the password of your Spotify account",
           "label": "TRANSLATE.SPOTIFY_PASSWORD",
+          "value": ""
+        },
+        {
+          "id": "lastfmusername",
+          "type":"text",
+          "element": "input",
+          "doc": "This is the username of your Last.fm account",
+          "label": "TRANSLATE.LAST_FM_USERNAME",
+          "value": ""
+        },
+        {
+          "id": "lastfmpassword",
+          "type":"password",
+          "element": "input",
+          "doc": "This is the password of your Last.fm account",
+          "label": "TRANSLATE.LAST_FM_PASSWORD",
           "value": ""
         },
         {

--- a/plugins/music_service/spotify/config.json
+++ b/plugins/music_service/spotify/config.json
@@ -11,6 +11,14 @@
     "type": "string",
     "value": ""
   },
+  "lastfmusername": {
+    "type": "string",
+    "value": ""
+  },
+  "lastfmpassword": {
+    "type": "string",
+    "value": ""
+  },
   "bitrate": {
     "type": "boolean",
     "value": true

--- a/plugins/music_service/spotify/index.js
+++ b/plugins/music_service/spotify/index.js
@@ -1104,7 +1104,9 @@ ControllerSpop.prototype.getUIConfig = function() {
 
 			uiconf.sections[0].content[0].value = self.config.get('username');
 			uiconf.sections[0].content[1].value = self.config.get('password');
-			uiconf.sections[0].content[2].value = self.config.get('bitrate');
+			uiconf.sections[0].content[2].value = self.config.get('lastfmusername');
+			uiconf.sections[0].content[3].value = self.config.get('lastfmpassword');
+			uiconf.sections[0].content[4].value = self.config.get('bitrate');
 
 			defer.resolve(uiconf);
 		})
@@ -1726,10 +1728,12 @@ ControllerSpop.prototype.createSPOPDFile = function () {
 
 			var conf1 = data.replace("${username}", self.config.get('username'));
 			var conf2 = conf1.replace("${password}", self.config.get('password'));
-			var conf3 = conf2.replace("${bitrate}", self.config.get('bitrate'));
-			var conf4 = conf3.replace("${outdev}", hwdev);
+			var conf3 = conf2.replace("${lastfmusername}", self.config.get('lastfmusername'));
+			var conf4 = conf3.replace("${lastfmpassword}", self.config.get('lastfmpassword'));
+			var conf5 = conf4.replace("${bitrate}", self.config.get('bitrate'));
+			var conf6 = conf5.replace("${outdev}", hwdev);
 
-			fs.writeFile("/etc/spopd.conf", conf4, 'utf8', function (err) {
+			fs.writeFile("/etc/spopd.conf", conf6, 'utf8', function (err) {
 				if (err)
 					defer.reject(new Error(err));
 				else defer.resolve();
@@ -1756,6 +1760,8 @@ ControllerSpop.prototype.saveSpotifyAccount = function (data) {
 
 	self.config.set('username', data['username']);
 	self.config.set('password', data['password']);
+	self.config.set('lastfmusername', data['lastfmusername']);
+	self.config.set('lastfmpassword', data['lastfmpassword']);
 	self.config.set('bitrate', data['bitrate']);
 
 	self.rebuildSPOPDAndRestartDaemon()

--- a/plugins/music_service/spotify/package.json
+++ b/plugins/music_service/spotify/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "spop",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"description": "Spotify plugin for Volumio2",
 	"main": "index.js",
 	"scripts": {

--- a/plugins/music_service/spotify/spop.conf.tmpl
+++ b/plugins/music_service/spotify/spop.conf.tmpl
@@ -8,6 +8,12 @@ audio_output = sox
 pretty_json = true
 search_results = 50
 cache_path =/run/shm
+plugins = scrobble
+
+[scrobble]
+api_endpoint = http://post.audioscrobbler.com:80/
+username = ${lastfmusername}
+password = ${lastfmpassword}
 
 [sox]
 output_type = alsa


### PR DESCRIPTION
I noticed that Last.fm support hadn't been implemented in the GUI or config for Spop, so I've just added code to enable it in the GUI.
While testing though, I noticed I had to remove the old config.json in /data/configuration/music_service/spop/