### PR TITLE
Backup & Restore Data plugin in proper category

### DIFF
--- a/plugins/volumio/armhf/plugins.json
+++ b/plugins/volumio/armhf/plugins.json
@@ -142,6 +142,24 @@
 						}
 					],
 					"updated": "14-10-2017"
+				},
+				{
+					"prettyName": "Backup & Restore Data",
+					"icon": "fa-floppy-o",
+					"name": "backup_restore",
+					"version": "0.7.2",
+					"url": "http://volumio.github.io/volumio-plugins/plugins/volumio/armhf/system_controller/backup_restore/backup_restore.zip",
+					"license": "ISC",
+					"description": "This plugin allows User to locally backup volumio data (playlists, settings, etc) and restore later",
+					"details":"<h4>Backup & Restore Plugin</h4><br>Locally back-up and restore Volumio data<br><br>Choose which sets of data you want to archive (queue, playlist, Favourites, Configuration, Album Art), and hit backup button:<br>Generated archive file will then be available from Volumio SMB share.<br>That file may be copied & put-back in similar location on another (or re-imaged) device for restore.",
+					"author": "macmpi",
+					"screenshots": [
+						{
+							"image": "",
+							"thumb": ""
+						}
+					],
+					"updated": "18-11-2017"
 				}
 			]
 		},
@@ -176,26 +194,7 @@
 					"author": "Volumio Team",
 					"screenshots": [],
 					"updated": "11-11-2016"
-				},
-				{
-					"prettyName": "Backup & Restore Data",
-					"icon": "fa-lightbulb-o",
-					"name": "backup_restore",
-					"version": "0.7.2",
-					"url": "http://volumio.github.io/volumio-plugins/plugins/volumio/armhf/system_controller/backup_restore/backup_restore.zip",
-					"license": "ISC",
-					"description": "This plugin allows User to locally backup volumio data (playlists, settings, etc) and restore later",
-					"details": "This plugin allows to backup settings, albumarts, queue, playlists, favourites and restore them. ",
-					"author": "macmpi",
-					"screenshots": [
-						{
-							"image": "",
-							"thumb": ""
-						}
-					],
-					"updated": "18-11-2017"
-				}
-			]
+				}			]
 		}
 	]
 }


### PR DESCRIPTION
Was mistakenly described in accessory category although actual plugin is in system_controller.
Also updated icon and details description [as per original post](https://github.com/volumio/volumio-plugins/pull/110#issue-267673588).

This plugin is not architecture dependent, so it should work as-is on x86: you may want to publish there too.