### PR TITLE
Updated package.json

### DIFF
--- a/plugins/user_interface/rotaryencoder/package.json
+++ b/plugins/user_interface/rotaryencoder/package.json
@@ -34,7 +34,7 @@
 		"net": "^1.0.2",
 		"once": "^1.4.0",
 		"onoff": "^1.1.9",
-		"onoff-rotary": "^0.2.1",
+		"onoff-rotary": "https://github.com/Saiyato/onoff-rotary/tarball/ebfbc16a0806762b2e08ab40a539f0fcd3302506",
 		"path-is-absolute": "^1.0.1",
 		"rimraf": "^2.6.2",
 		"slide": "^1.1.6",


### PR DESCRIPTION
The rotary encoder plugin uses a custom onoff-rotary library, updated the package.json to pull it from my github repo.

fixes #136