### PR TITLE
Back-up&Restore: update plugins.json

### DIFF
--- a/plugins/volumio/armhf/plugins.json
+++ b/plugins/volumio/armhf/plugins.json
@@ -234,13 +234,13 @@
 				},
 				{
 					"prettyName": "Backup & Restore Data",
-					"icon": "fa-lightbulb-o",
+					"icon": "fa-floppy-o",
 					"name": "backup_restore",
 					"version": "0.7.2",
 					"url": "http://volumio.github.io/volumio-plugins/plugins/volumio/armhf/system_controller/backup_restore/backup_restore.zip",
 					"license": "ISC",
 					"description": "This plugin allows User to locally backup volumio data (playlists, settings, etc) and restore later",
-					"details": "This plugin allows to backup settings, albumarts, queue, playlists, favourites and restore them. ",
+					"details":"<h4>Backup & Restore Plugin</h4><br>Locally back-up and restore Volumio data<br><br>Choose which sets of data you want to archive (queue, playlist, Favourites, Configuration, Album Art), and hit backup button:<br>Generated archive file will then be available from Volumio SMB share.<br>That file may be copied & put-back in similar location on another (or re-imaged) device for restore.",
 					"author": "macmpi",
 					"screenshots": [
 						{

--- a/plugins/volumio/i386/plugins.json
+++ b/plugins/volumio/i386/plugins.json
@@ -38,34 +38,33 @@
 			"name": "system_controller",
 			"id": "cat3",
 			"description": "Volumio System Tools",
-			"plugins": []
+			"plugins": [
+				{
+					"prettyName": "Backup & Restore Data",
+					"icon": "fa-floppy-o",
+					"name": "backup_restore",
+					"version": "0.7.2",
+					"url": "http://volumio.github.io/volumio-plugins/plugins/volumio/armhf/system_controller/backup_restore/backup_restore.zip",
+					"license": "ISC",
+					"description": "This plugin allows User to locally backup volumio data (playlists, settings, etc) and restore later",
+					"details":"<h4>Backup & Restore Plugin</h4><br>Locally back-up and restore Volumio data<br><br>Choose which sets of data you want to archive (queue, playlist, Favourites, Configuration, Album Art), and hit backup button:<br>Generated archive file will then be available from Volumio SMB share.<br>That file may be copied & put-back in similar location on another (or re-imaged) device for restore.",
+					"author": "macmpi",
+					"screenshots": [
+						{
+							"image": "",
+							"thumb": ""
+						}
+					],
+					"updated": "18-11-2017"
+				}
+			]
 		},
 		 {
                         "prettyName": "Accessories",
                         "name": "accessory",
                         "id": "cat3",
                         "description": "Plugins for Volumio Accessories",
-                        "plugins": [
-				{
-                                        "prettyName": "Backup & Restore Data",
-                                        "icon": "fa-lightbulb-o",
-                                        "name": "backup_restore",
-                                        "version": "0.7.2",
-                                        "url": "http://volumio.github.io/volumio-plugins/plugins/volumio/i386/system_controller/backup_restore/backup_restore.zip",
-                                        "license": "ISC",
-                                        "description": "This plugin allows User to locally backup volumio data (playlists, settings, etc) and restore later",
-                                        "details": "This plugin allows to backup settings, albumarts, queue, playlists, favourites and restore them. ",
-                                        "author": "macmpi",
-                                        "screenshots": [
-                                                {
-                                                        "image": "",
-                                                        "thumb": ""
-                                                }
-                                        ],
-                                        "updated": "18-11-2017"
-                                }
-	
-		]
+                        "plugins": []
 }
 ]
 }


### PR DESCRIPTION
Make sure armhf and x86 `plugins.json` are in consistent categories.
Also updates icon and detailed description fields as originally intended.

Hope this will finally set it right after cancelled https://github.com/volumio/volumio-plugins/pull/113