### PR TITLE
created own folder for activities to decrease number of api queries

### DIFF
--- a/plugins/music_service/youtube/index.js
+++ b/plugins/music_service/youtube/index.js
@@ -251,6 +251,8 @@ Youtube.prototype.handleBrowseUri = function (uri) {
       return self.getUserPlaylists();
     } else if (uri.startsWith('youtube/root/likedVideos')) {
       return self.getUserLikedVideos();
+    } else if (uri.startsWith('youtube/root/activities')) {
+      return self.getActivities();
     } else if (uri.startsWith('youtube/playlist/')) {
       return self.getPlaylistItems(uri.split('/').pop());
     } else if (uri.startsWith('youtube/channel/')) {
@@ -524,39 +526,52 @@ Youtube.prototype.getRootContent = function () {
     return self.getTrend();
   }
 
-  var deferred = self.getActivities()
-    .then(function (activities) {
-      activities.navigation.lists.unshift({
-        title: 'My Youtube',
-        icon: 'fa fa-youtube',
-        availableListViews: ['list', 'grid'],
-        items: [{
-          service: 'youtube',
-          type: 'folder',
-          title: 'Subscriptions',
-          icon: 'fa fa-folder-open-o',
-          uri: 'youtube/root/subscriptions'
+  return libQ.resolve(
+    {
+      navigation: {
+        prev: {
+          uri: '/'
         },
-        {
-          service: 'youtube',
-          type: 'folder',
-          title: 'My Playlists',
-          icon: 'fa fa-folder-open-o',
-          uri: 'youtube/root/playlists'
-        },
-        {
-          service: 'youtube',
-          type: 'folder',
-          title: 'Liked Videos',
-          icon: 'fa fa-folder-open-o',
-          uri: 'youtube/root/likedVideos'
-        }
-        ]
-      });
-      return activities;
+        lists:
+          [
+            {
+              title: 'My Youtube',
+              icon: 'fa fa-youtube',
+              availableListViews: ['list', 'grid'],
+              items: [
+                {
+                  service: 'youtube',
+                  type: 'folder',
+                  title: ' Activities',
+                  icon: 'fa fa-folder-open-o',
+                  uri: 'youtube/root/activities'
+                },
+                {
+                  service: 'youtube',
+                  type: 'folder',
+                  title: 'Subscriptions',
+                  icon: 'fa fa-folder-open-o',
+                  uri: 'youtube/root/subscriptions'
+                },
+                {
+                  service: 'youtube',
+                  type: 'folder',
+                  title: 'My Playlists',
+                  icon: 'fa fa-folder-open-o',
+                  uri: 'youtube/root/playlists'
+                },
+                {
+                  service: 'youtube',
+                  type: 'folder',
+                  title: 'Liked Videos',
+                  icon: 'fa fa-folder-open-o',
+                  uri: 'youtube/root/likedVideos'
+                }
+              ]
+            }
+          ]
+      }
     });
-
-  return deferred;
 }
 
 Youtube.prototype.getUserSubscriptions = function () {
@@ -630,7 +645,7 @@ Youtube.prototype.getActivities = function () {
     apiFunc: self.yt.activities.list,
     apiRequest: request,
     loadAll: true,
-    prevUri: '/',
+    prevUri: 'youtube',
     title: 'Youtube activities',
   });
 }

--- a/plugins/music_service/youtube/package.json
+++ b/plugins/music_service/youtube/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "youtube",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"description": "Youtube playback and public sharing for the Volumio",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Hello volumio team,

may you have noticed that the YouTube plugin has reached the quota of queries per day this weekend. There was a request in the volumio forum, see [here](https://volumio.org/forum/youtube-for-volumio-t6608-90.html#p47036). The used YouTube API v3 key is allowed to query 1.000.000 times and this quota was reached. 

To reduce the number of queries I have moved the activities that are shown when the user clicks on "YouTube" to a folder. So we can save a lot of the quota for real user requests.

This issue only occurs when the user has granted the plugin access to the YouTube account.

Hope you will accept the PR.

With best regards,
Stefan
