### PR TITLE
Enable TuneIn Radio plugin for x86

### DIFF
--- a/plugins/volumio/i386/plugins.json
+++ b/plugins/volumio/i386/plugins.json
@@ -77,6 +77,24 @@
 						}
 					],
 					"updated": "3-4-2018"
+				},
+				{
+					"prettyName": "TuneIn Radio",
+					"icon": "fa-lightbulb-o",
+					"name": "tunein_radio",
+					"version": "1.1.0",
+					"url": "http://volumio.github.io/volumio-plugins/plugins/volumio/armhf/music_service/tunein_radio/tunein_radio.zip",
+					"license": "ISC",
+					"description": "Support radio streaming from the TuneIn Radio service",
+					"details": "Support radio streaming from the TuneIn Radio service",
+					"author": "Piffio",
+					"screenshots": [
+						{
+							"image": "",
+							"thumb": ""
+						}
+					],
+					"updated": "19-3-2018"
 				}
 			]
 		},


### PR DESCRIPTION
Just realized that the plugin was only enabled for ARM based images, and since it does not use any binary module it should be safe to be distributed for x86 as well