### PR TITLE
Add getConfigurationFiles to example plugin

### DIFF
--- a/example_plugin/index.js
+++ b/example_plugin/index.js
@@ -82,6 +82,9 @@ ControllerExamplePlugin.prototype.getUIConfig = function() {
     return defer.promise;
 };
 
+ControllerExamplePlugin.prototype.getConfigurationFiles = function() {
+	return ['config.json'];
+}
 
 ControllerExamplePlugin.prototype.setUIConfig = function(data) {
 	var self = this;


### PR DESCRIPTION
Hi,

The example plugin does not have the getConfigurationFiles function.

If this is not included the plugin config does not work at all! (As I just found out)

Recommend this is added to the example plugin (I assume the plugin helper uses this as a base?)