### PR TITLE
New upload audiophonics on/off

### DIFF
--- a/plugins/system_controller/audiophonicsonoff/LICENSE
+++ b/plugins/system_controller/audiophonicsonoff/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Rachid Groeneveld
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/system_controller/audiophonicsonoff/README.md
+++ b/plugins/system_controller/audiophonicsonoff/README.md
@@ -1,0 +1,14 @@
+# volumio-audiophonicsonoff-plugin
+Volumio plugin to configure the power button (with backlight) behavior connected to an Audiophonics Sabre soundcard 
+
+Information from Jedail is used, because I wanted to use pydPiper for the LCD I stripped the LCD code.
+Source: https://github.com/JedS/Raspdac
+
+You can configure three GPIO pins:
+
+1. The GPIO pin which is set to HIGH when Volumio receives a shutdown command
+2. The GPIO pin which is set to HIGH when the power button is pressed
+3. The GPIO pin which is set to HIGH after booting successfully (i.e. Volumio and this plugin have started)
+
+## pydPiper
+The pydPiper plugin can be found here: https://github.com/Saiyato/volumio-pydpiper-plugin

--- a/plugins/system_controller/audiophonicsonoff/UIConfig.json
+++ b/plugins/system_controller/audiophonicsonoff/UIConfig.json
@@ -1,0 +1,53 @@
+{
+	"page": {
+		"label": "TRANSLATE.AUDIOPHONICSONOFF.PLUGINCONF"
+	},
+	"sections": [{
+		"id": "pin_settings",
+		"element": "section",
+		"label": "TRANSLATE.AUDIOPHONICSONOFF.GPIOCONFIG",
+		"description": "TRANSLATE.AUDIOPHONICSONOFF.D_GPIOCONFIG",
+		"icon": "fa-sliders",
+		"onSave": {
+			"type": "controller",
+			"endpoint": "system_controller/audiophonicsonoff",
+			"method": "updateButtonConfig"
+		},
+		"saveButton": {
+			"label": "TRANSLATE.AUDIOPHONICSONOFF.SAVE",
+			"data": [
+					"soft_shutdown",
+					"shutdown_button",
+					"boot_ok"
+				]
+		},
+		"content": [
+		{
+			"id": "soft_shutdown",
+			"element": "input",
+			"type": "text",
+			"doc": "TRANSLATE.AUDIOPHONICSONOFF.D_SOFTSHUTDOWN",
+			"label": "TRANSLATE.AUDIOPHONICSONOFF.SOFTSHUTDOWN",
+			"description": "TRANSLATE.AUDIOPHONICSONOFF.DD_SOFTSHUTDOWN",
+			"value": "4"
+		},
+		{
+			"id": "shutdown_button",
+			"element": "input",
+			"type": "text",
+			"doc": "TRANSLATE.AUDIOPHONICSONOFF.D_SHUTDOWNBUTTON",
+			"label": "TRANSLATE.AUDIOPHONICSONOFF.SHUTDOWNBUTTON",
+			"description": "TRANSLATE.AUDIOPHONICSONOFF.DD_SHUTDOWNBUTTON",
+			"value": "17"
+		},
+		{
+			"id": "boot_ok",
+			"element": "input",
+			"type": "text",
+			"doc": "TRANSLATE.AUDIOPHONICSONOFF.D_BOOTOK",
+			"label": "TRANSLATE.AUDIOPHONICSONOFF.BOOTOK",
+			"description": "TRANSLATE.AUDIOPHONICSONOFF.DD_BOOTOK",
+			"value": "22"
+		}]
+	}]
+}

--- a/plugins/system_controller/audiophonicsonoff/config.json
+++ b/plugins/system_controller/audiophonicsonoff/config.json
@@ -1,0 +1,14 @@
+{
+  "soft_shutdown": {
+    "type": "string",
+    "value": "4"
+  },
+  "shutdown_button": {
+    "type": "string",
+    "value": "17"
+  },
+  "boot_ok": {
+    "type": "string",
+    "value": "22"
+  }
+}

--- a/plugins/system_controller/audiophonicsonoff/i18n/strings_en.json
+++ b/plugins/system_controller/audiophonicsonoff/i18n/strings_en.json
@@ -1,0 +1,17 @@
+{
+	"AUDIOPHONICSONOFF":{
+	"PLUGINCONF":"Audiophonics on/off button configuration",
+	"GPIOCONFIG":"GPIO configuration",
+	"D_GPIOCONFIG":"Configure the GPIO pins to use for the Audiophonics card and on/off button. The Audiophonics Sabre soundcard has scripts on the chip to flash the power button while booting/shutting down (faster blinking) and it will light it up once booted. This plugin allows for easy configuration of this behavior.",
+		"SOFTSHUTDOWN": "Software shutdown GPIO pin",
+		"D_SOFTSHUTDOWN":"Controls which GPIO pin is activated (HIGH) when a shutdown is initiated from software.",
+		"DD_SOFTSHUTDOWN":"Default = 4, set to HIGH when Volumio receives a shutdown command",
+		"SHUTDOWNBUTTON":"Shutdown button GPIO pin",
+		"D_SHUTDOWNBUTTON":"Controls which GPIO pin is activated (HIGH) when the hardware button is pressed.",
+		"DD_SHUTDOWNBUTTON":"Default = 17, set to HIGH when the power button is pressed",
+		"BOOTOK": "Successful boot GPIO pin",
+		"D_BOOTOK":"Controls which GPIO pin is activated (HIGH) after booting successfully.",
+		"DD_BOOTOK":"Default = 22, set to HIGH after boot",
+	"SAVE": "Save"
+	}
+}

--- a/plugins/system_controller/audiophonicsonoff/index.js
+++ b/plugins/system_controller/audiophonicsonoff/index.js
@@ -1,0 +1,205 @@
+'use strict';
+var libQ = require('kew');
+var libNet = require('net');
+var fs = require('fs-extra');
+var config = new (require('v-conf'))();
+var exec = require('child_process').exec;
+var Gpio = require('onoff').Gpio;
+
+module.exports = ControllerAudiophonicsOnOff;
+
+function ControllerAudiophonicsOnOff(context) 
+{
+	var self = this;
+
+	this.context = context;
+	this.commandRouter = this.context.coreCommand;
+	this.logger = this.context.logger;
+	this.configManager = this.context.configManager;
+};
+
+ControllerAudiophonicsOnOff.prototype.onVolumioStart = function()
+{
+	var self = this;
+	self.logger.info("Audiophonics on/off initiated");
+	
+	this.configFile = this.commandRouter.pluginManager.getConfigurationFile(this.context, 'config.json');
+	self.getConf(this.configFile);
+	
+	return libQ.resolve();	
+};
+
+ControllerAudiophonicsOnOff.prototype.onVolumioReboot = function()
+{
+      var self = this;
+      self.softShutdown.writeSync(1);
+};
+
+ControllerAudiophonicsOnOff.prototype.onVolumioShutdown = function()
+{
+      var self = this;
+      var defer = libQ.defer();
+      
+      self.softShutdown.writeSync(1);
+      setTimeout(function(){
+            self.softShutdown.writeSync(0);
+            defer.resolve();
+          }, 1000);
+      
+      return defer;
+};
+
+ControllerAudiophonicsOnOff.prototype.getConfigurationFiles = function()
+{
+	return ['config.json'];
+};
+
+// Plugin methods -----------------------------------------------------------------------------
+ControllerAudiophonicsOnOff.prototype.onStop = function() {
+	var self = this;
+	self.logger.info("performing onStop action");
+	
+	self.shutdownButton.unwatchAll();
+	self.shutdownButton.unexport();
+	self.bootOk.unexport();
+	self.softShutdown.unexport();
+	
+	return libQ.resolve();
+};
+
+ControllerAudiophonicsOnOff.prototype.stop = function() {
+	var self = this;
+	self.logger.info("performing stop action");
+	
+	return libQ.resolve();
+};
+
+ControllerAudiophonicsOnOff.prototype.onStart = function() {
+	var self = this;
+	self.logger.info("Configuring GPIO pins");
+	
+	if(self.tryParse(self.config.get('soft_shutdown'), 0) != 0)
+	{
+		self.softShutdown = new Gpio(parseInt(self.config.get('soft_shutdown')), 'out')
+		self.logger.info('Soft shutdown GPIO binding... OK');
+	}
+	
+	if(self.tryParse(self.config.get('shutdown_button'), 0) != 0)
+	{
+		self.shutdownButton = new Gpio(parseInt(self.config.get('shutdown_button')), 'in', 'both');
+		self.logger.info('Hardware button GPIO binding... OK');
+	}
+	
+	if(self.tryParse(self.config.get('boot_ok'), 0) != 0)
+	{
+		self.bootOk = new Gpio(parseInt(self.config.get('boot_ok')), 'high');
+		self.logger.info('Boot OK GPIO binding... OK');
+	}
+	
+	self.shutdownButton.watch(self.hardShutdownRequest.bind(this));
+	
+	return libQ.resolve();
+};
+
+ControllerAudiophonicsOnOff.prototype.onRestart = function() 
+{
+	var self = this;
+	self.logger.info("performing onRestart action");
+};
+
+ControllerAudiophonicsOnOff.prototype.onInstall = function() 
+{
+	var self = this;
+	self.logger.info("performing onInstall action");
+};
+
+ControllerAudiophonicsOnOff.prototype.onUninstall = function() 
+{
+	// Perform uninstall tasks here!
+	self.logger.info("performing onUninstall action");
+};
+
+ControllerAudiophonicsOnOff.prototype.getUIConfig = function() {
+    var self = this;
+	var defer = libQ.defer();    
+    var lang_code = this.commandRouter.sharedVars.get('language_code');
+	self.getConf(this.configFile);
+	self.logger.info("Loaded the previous config.");
+		
+	self.commandRouter.i18nJson(__dirname+'/i18n/strings_' + lang_code + '.json',
+		__dirname + '/i18n/strings_en.json',
+		__dirname + '/UIConfig.json')
+    .then(function(uiconf)
+    {
+		self.logger.info("## populating UI...");
+		
+		// GPIO configuration
+		uiconf.sections[0].content[0].value = self.config.get('soft_shutdown');
+		uiconf.sections[0].content[1].value = self.config.get('shutdown_button');
+		uiconf.sections[0].content[2].value = self.config.get('boot_ok');		
+		self.logger.info("1/1 settings loaded");
+		
+		self.logger.info("Populated config screen.");
+		
+		defer.resolve(uiconf);
+	})
+	.fail(function()
+	{
+		defer.reject(new Error());
+	});
+
+	return defer.promise;
+};
+
+ControllerAudiophonicsOnOff.prototype.setUIConfig = function(data) {
+	var self = this;
+	
+	self.logger.info("Updating UI config");
+	var uiconf = fs.readJsonSync(__dirname + '/UIConfig.json');
+	
+	return libQ.resolve();
+};
+
+ControllerAudiophonicsOnOff.prototype.getConf = function(configFile) {
+	var self = this;
+	this.config = new (require('v-conf'))()
+	this.config.loadFile(configFile)
+	
+	return libQ.resolve();
+};
+
+ControllerAudiophonicsOnOff.prototype.setConf = function(conf) {
+	var self = this;
+	return libQ.resolve();
+};
+
+// Public Methods ---------------------------------------------------------------------------------------
+ControllerAudiophonicsOnOff.prototype.updateButtonConfig = function (data)
+{
+	var self = this;
+	
+	self.config.set('soft_shutdown', data['soft_shutdown']);
+	self.config.set('shutdown_button', data['shutdown_button']);
+	self.config.set('boot_ok', data['boot_ok']);
+	
+	self.commandRouter.pushToastMessage('success', 'Successfully saved the new configuration.');
+	return libQ.resolve();
+};
+
+// Button Management
+ControllerAudiophonicsOnOff.prototype.hardShutdownRequest = function(err, value) {
+	var self = this;
+	self.commandRouter.shutdown();
+};
+
+ControllerAudiophonicsOnOff.prototype.tryParse = function(str,defaultValue) {
+     var retValue = defaultValue;
+     if(str !== null) {
+         if(str.length > 0) {
+             if (!isNaN(str)) {
+                 retValue = parseInt(str);
+             }
+         }
+     }
+     return retValue;
+};

--- a/plugins/system_controller/audiophonicsonoff/install.sh
+++ b/plugins/system_controller/audiophonicsonoff/install.sh
@@ -1,0 +1,19 @@
+## Character display installation script
+echo "Installing Audiophonics on/off and its dependencies..."
+INSTALLING="/home/volumio/audiophonicsonoff-plugin.installing"
+
+if [ ! -f $INSTALLING ]; then
+
+	touch $INSTALLING
+
+	# Download installation package
+	echo "No packages needed, only node_modules are required"
+	# Perform any kind of wget/apt-get install/dpkg -i/etc.
+	
+	rm $INSTALLING
+
+	#required to end the plugin install
+	echo "plugininstallend"
+else
+	echo "Plugin is already installing! Not continuing..."
+fi

--- a/plugins/system_controller/audiophonicsonoff/package.json
+++ b/plugins/system_controller/audiophonicsonoff/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "audiophonicsonoff",
+  "version": "1.0.3",
+  "description": "Minimized Audiophonics plugin for button management, copied from RaspDac by Jedail",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Saiyato",
+  "license": "GPL-3.0",
+  "volumio_info": {
+    "prettyName": "Audiophonics ON/OFF",
+    "icon": "fa fa-cogs",
+    "plugin_type": "system_controller"
+  },
+  "dependencies": {
+	"balanced-match": "^1.0.0",
+	"bindings": "^1.3.0",
+	"brace-expansion": "^1.1.11",
+	"concat-map": "^0.0.1",
+	"epoll": "^1.0.2",
+	"fs-extra": "^0.28.0",
+	"fs.realpath": "^1.0.0",
+	"glob": "^7.1.2",
+	"graceful-fs": "^4.1.11",
+	"imurmurhash": "^0.1.4",
+	"inflight": "^1.0.6",
+	"inherits": "^2.0.3",
+	"jsonfile": "^2.4.0",
+	"kew": "^0.7.0",
+	"klaw": "^1.3.1",
+	"minimatch": "^3.0.4",
+	"multimap": "^1.0.2",
+	"nan": "^2.8.0",
+	"net": "^1.0.2",
+	"once": "^1.4.0",
+	"onoff": "^1.2.0",
+	"path-is-absolute": "^1.0.1",
+	"rimraf": "^2.6.2",
+	"slide": "^1.1.6",
+	"v-conf": "^1.4.2",
+	"wrappy": "^1.0.2",
+	"write-file-atomic": "^1.3.4"
+  },
+  "devDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Saiyato/volumio-audiophonicsonoff-plugin.git"
+  },
+  "keywords": [
+    "Audiophonics",
+	"button",
+    "volumio"
+  ],
+  "bugs": {
+    "url": "https://github.com/Saiyato/volumio-audiophonicsonoff-plugin/issues"
+  },
+  "homepage": "https://github.com/Saiyato/volumio-audiophonicsonoff-plugin#readme"
+}

--- a/plugins/system_controller/audiophonicsonoff/uninstall.sh
+++ b/plugins/system_controller/audiophonicsonoff/uninstall.sh
@@ -1,0 +1,15 @@
+## Character display uninstallation script
+echo "Uninstalling Audiophonics on/off and its dependencies..."
+INSTALLING="/home/volumio/audiophonicsonoff-plugin.uninstalling"
+
+if [ ! -f $INSTALLING ]; then
+
+	touch $INSTALLING
+
+	rm $INSTALLING
+
+	#required to end the plugin uninstall
+	echo "pluginuninstallend"
+else
+	echo "Plugin is already uninstalling! Not continuing..."
+fi


### PR DESCRIPTION
New plugin, which was never submitted properly. Repo: https://github.com/Saiyato/volumio-audiophonicsonoff-plugin

# volumio-audiophonicsonoff-plugin
Volumio plugin to configure the power button (with backlight) behavior connected to an Audiophonics Sabre soundcard 

Information from Jedail is used, because I wanted to use pydPiper for the LCD I stripped the LCD code.
Source: https://github.com/JedS/Raspdac

You can configure three GPIO pins:

1. The GPIO pin which is set to HIGH when Volumio receives a shutdown command
2. The GPIO pin which is set to HIGH when the power button is pressed
3. The GPIO pin which is set to HIGH after booting successfully (i.e. Volumio and this plugin have started)

## Configuration
Software shutdown: sends a high signal to this pin when a shutdown/restart is triggered from within Volumio
Shutdown button: when this pin detects a high signal, a shutdown sent to Volumio (software)
Successful boot: this is the BootOK trigger, when this plugin is started by Volumio, a high signal is sent to this pin