### PR TITLE
Fix url for ir_controller

### DIFF
--- a/plugins/volumio/armhf/plugins.json
+++ b/plugins/volumio/armhf/plugins.json
@@ -426,7 +426,7 @@
 					"icon": "fa-magic",
 					"name": "ir_controller",
 					"version": "1.2.0",
-					"url": "http://volumio.github.io/volumio-plugins/plugins/volumio/armhf/accessory/ir_remote_controller/ir.zip",
+					"url": "http://volumio.github.io/volumio-plugins/plugins/volumio/armhf/accessory/ir_controller/ir_controller.zip",
 					"license": "GPLv3",
 					"description": "Volumio IR Remote plugin",
 					"details": "<h4>IR Remote Controller Plugin </h4><br>This Plugin has been sponsored by <a href=\"https://www.justboom.co/?utm_source=JustBoom+Player&utm_medium=Software&utm_campaign=JustBoom+Player+Software&utm_content=IR+Remote+Plugin+Main+Site+Link\" target=\"blank\">JustBoom</a> and it works out of the box with <a href=\"https://www.justboom.co/product/justboom-ir-remote/?utm_source=JustBoom+Player&utm_medium=Software&utm_campaign=JustBoom+Player+Software&utm_content=IR+Remote+Plugin+Link\" target=\"blank\">JustBoom IR Remote</a><br><br>FEATURES: <br><br><ul><li>3 profiles available (JustBoom IR Remote, Odroid Remote, Apple remote)</li><li>Controls: Play, pause, mute, volume, next, previous, seek, repeat and random</li></ul>",


### PR DESCRIPTION
Fix for issue #169 

Initial commit https://github.com/volumio/volumio-plugins/commit/8011fe2606ecc8e51fe5bd8d82b1e38d2d32ec9e for the ir controller zip went into https://github.com/volumio/volumio-plugins/tree/gh-pages/plugins/volumio/armhf/accessory/ir_remote_controller
and the url in the plugins config reflected that.

However subsequent commits went into https://github.com/volumio/volumio-plugins/tree/gh-pages/plugins/volumio/armhf/accessory/ir_controller
(as per the path generated by the plugin helper)
The url does not get updated by the plugin helper on a plugin update (only on the initial creation) so the url refers the original version v1.0 not v1.2

Perhaps it's worthwhile doing another pull request to update the plugin helper so it updates the url on plugin update.