### PR TITLE
add missing "dpms" keyword to xset invocation

### DIFF
--- a/plugins/miscellanea/touch_display/install.sh
+++ b/plugins/miscellanea/touch_display/install.sh
@@ -67,7 +67,7 @@ echo "  Creating chromium kiosk start script"
 echo "#!/bin/bash
 xset +dpms
 xset s blank
-xset 0 0 120
+xset dpms 0 0 120
 openbox-session &
 while true; do
   /usr/bin/chromium-browser \\


### PR DESCRIPTION
before this patch the command would result in the error message "xset:  unknown option 0"