### PR TITLE
mute/unmute the amp before switching it off/on

### DIFF
--- a/plugins/miscellanea/ampswitch/UIConfig.json
+++ b/plugins/miscellanea/ampswitch/UIConfig.json
@@ -17,7 +17,10 @@
                           "delay_setting",
                           "latched_setting",
                           "on_pulse_width_setting",
-                          "off_pulse_width_setting"
+                          "off_pulse_width_setting",
+                          "deferred_unmute_setting",
+                          "muteport_setting",
+                          "unmute_delay_setting"
                           ]
                  },
                  "content": [
@@ -144,10 +147,10 @@
                              "doc": "TRANSLATE.INVERTED_DOC",
                              "value": false
                              },
-							               {
-							               "id": "delay_setting",
+                             {
+                             "id": "delay_setting",
                              "element": "input",
-							               "type": "number",
+                             "type": "number",
                              "label": "TRANSLATE.DELAY",
                              "doc": "TRANSLATE.DELAY_DOC",
                              "value": 1000
@@ -181,6 +184,146 @@
                              "options": [],
                                      "visibleIf": {
                                        "field": "latched_setting",
+                                       "value": true
+                                     }
+                             },
+                             {
+                             "id": "deferred_unmute_setting",
+                             "element": "switch",
+                             "label": "TRANSLATE.DEFERRED_UNMUTE",
+                             "doc": "TRANSLATE.DEFERRED_UNMUTE_DOC",
+                             "value": false
+                             },
+                             {
+                             "id": "muteport_setting",
+                             "element": "select",
+                             "doc": "TRANSLATE.MUTEPORT_DOC",
+                             "label": "TRANSLATE.MUTEPORT",
+                             "value": {
+                             "value": 16,
+                             "label": "16"
+                             },
+                             "options": [
+                                         {
+                                         "value": 2,
+                                         "label": "2"
+                                         },
+                                         {
+                                         "value": 3,
+                                         "label": "3"
+                                         },
+                                         {
+                                         "value": 4,
+                                         "label": "4"
+                                         },
+                                         {
+                                         "value": 5,
+                                         "label": "5"
+                                         },
+                                         {
+                                         "value": 6,
+                                         "label": "6"
+                                         },
+                                         {
+                                         "value": 7,
+                                         "label": "7"
+                                         },
+                                         {
+                                         "value": 8,
+                                         "label": "8"
+                                         },
+                                         {
+                                         "value": 9,
+                                         "label": "9"
+                                         },
+                                         {
+                                         "value": 10,
+                                         "label": "10"
+                                         },
+                                         {
+                                         "value": 11,
+                                         "label": "11"
+                                         },
+                                         {
+                                         "value": 12,
+                                         "label": "12"
+                                         },
+                                         {
+                                         "value": 13,
+                                         "label": "13"
+                                         },
+                                         {
+                                         "value": 14,
+                                         "label": "14"
+                                         },
+                                         {
+                                         "value": 15,
+                                         "label": "15"
+                                         },
+                                         {
+                                         "value": 16,
+                                         "label": "16"
+                                         },
+                                         {
+                                         "value": 17,
+                                         "label": "17"
+                                         },
+                                         {
+                                         "value": 18,
+                                         "label": "18"
+                                         },
+                                         {
+                                         "value": 19,
+                                         "label": "19"
+                                         },
+                                         {
+                                         "value": 20,
+                                         "label": "20"
+                                         },
+                                         {
+                                         "value": 21,
+                                         "label": "21"
+                                         },
+                                         {
+                                         "value": 22,
+                                         "label": "22"
+                                         },
+                                         {
+                                         "value": 23,
+                                         "label": "23"
+                                         },
+                                         {
+                                         "value": 24,
+                                         "label": "24"
+                                         },
+                                         {
+                                         "value": 25,
+                                         "label": "25"
+                                         },
+                                         {
+                                         "value": 26,
+                                         "label": "26"
+                                         },
+                                         {
+                                         "value": 27,
+                                         "label": "27"
+                                         }
+                                         ],
+                                     "visibleIf": {
+                                       "field": "deferred_unmute_setting",
+                                       "value": true
+                                     }
+                             },
+                             {
+                             "id": "unmute_delay_setting",
+                             "element": "input",
+                             "type": "number",
+                             "label": "TRANSLATE.UNMUTE_DELAY",
+                             "doc": "TRANSLATE.UNMUTE_DELAY_DOC",
+                             "value": 500,
+                             "options": [],
+                                     "visibleIf": {
+                                       "field": "deferred_unmute_setting",
                                        "value": true
                                      }
                              }

--- a/plugins/miscellanea/ampswitch/config.json
+++ b/plugins/miscellanea/ampswitch/config.json
@@ -22,5 +22,17 @@
     "off_pulse_width":{
         "type": "number",
         "value": 500
-    }
+    },
+    "deferred_unmute":{
+        "type": "boolean",
+        "value": false
+    },
+    "muteport": {
+        "type": "number",
+        "value": 16
+    },
+    "unmute_delay": {
+        "type": "number",
+        "value": 550
+   }
 }

--- a/plugins/miscellanea/ampswitch/i18n/strings_de.json
+++ b/plugins/miscellanea/ampswitch/i18n/strings_de.json
@@ -13,5 +13,11 @@
   "ON_PULSE_WIDTH_DOC": "Dauer des Stromimpulses in ms",
   "OFF_PULSE_WIDTH": "Ausschaltimpulsdauer",
   "OFF_PULSE_WIDTH_DOC": "Dauer des Stromimpulses in ms",
-  "SAVE":"Speichern"
+  "SAVE":"Speichern",
+  "DEFERRED_UNMUTE": "Stummschalten",
+  "DEFERRED_UNMUTE_DOC": "Schaltet den Verstärker stumm, bevor er ausgeschaltet wird",
+  "MUTEPORT": "Port (Stumm)",
+  "MUTEPORT_DOC": "Ausgang zum Stummschalten des Verstärkers",
+  "UNMUTE_DELAY": "Lautschaltverzögerung",
+  "UNMUTE_DELAY_DOC": "Zeit zwischen Einschalten und Lautschalten des Verstärkers"
 }

--- a/plugins/miscellanea/ampswitch/i18n/strings_en.json
+++ b/plugins/miscellanea/ampswitch/i18n/strings_en.json
@@ -13,5 +13,11 @@
   "ON_PULSE_WIDTH_DOC": "Duration of pulse in ms",
   "OFF_PULSE_WIDTH": "Off Pulse width",
   "OFF_PULSE_WIDTH_DOC": "Duration of pulse in ms",
-  "SAVE":"Save"
+  "SAVE":"Save",
+  "DEFERRED_UNMUTE": "Mute",
+  "DEFERRED_UNMUTE_DOC": "Mutes amp before shutting it down",
+  "MUTEPORT": "Mute Port",
+  "MUTEPORT_DOC": "Output port on your device for muting the amp",
+  "UNMUTE_DELAY": "Unmute Delay",
+  "UNMUTE_DELAY_DOC": "Time between switching on and unmuting amp"
 }


### PR DESCRIPTION
  - When using e. g. a Hifiberry miniamp, switching the amp on will
  produce an audible pop noise independent of the volumio volume
  setting.
  - This introduces three new parameters:
    - deferred_unmute: enable the feature (defaults to off)
    - muteport: a GPIO port that will mute the amp
    - unmute_delay: time before unmuting the amp after switching it
    back on
  - Not used in latched mode, since I can not test this.