### PR TITLE
Update to allow setting GPIO pin for IR receiver on rpi (needs reboot)

### DIFF
--- a/plugins/accessory/ir_controller/UIConfig.json
+++ b/plugins/accessory/ir_controller/UIConfig.json
@@ -30,6 +30,29 @@
 
         }
       ]
+    },
+    {
+      "id":"rpi_conf",
+      "element": "section",
+      "label": "TRANSLATE.PI_CONFIGURATION",
+      "icon":"fa-microchip",
+      "onSave": {"type":"controller","endpoint":"accessory/ir_controller","method":"savePiOptions"},
+      "saveButton": {
+        "label": "TRANSLATE.SAVE",
+        "data": [
+          "pi_gpio_in"
+        ]
+      },
+      "content": [
+        {
+          "id": "pi_gpio_in",
+          "element" : "input",
+          "type": "text",
+          "doc":"TRANSLATE.GPIO_IN_DOC",
+          "label":"TRANSLATE.GPIO_IN",
+          "value": {}
+        }
+      ]
     }
   ]
 }

--- a/plugins/accessory/ir_controller/i18n/strings_en.json
+++ b/plugins/accessory/ir_controller/i18n/strings_en.json
@@ -2,5 +2,8 @@
   "IR_CONFIGURATION":"IR Remote Configuration",
   "SAVE": "Save",
   "PROFILE_SELECTOR": "Select profile",
-  "PROFILE_SELECTOR_DOC": "Select the appropriate configuration for your remote from the available profiles"
+  "PROFILE_SELECTOR_DOC": "Select the appropriate configuration for your remote from the available profiles",
+  "PI_CONFIGURATION":"Raspberry Pi GPIO Configuration",
+  "GPIO_IN": "GPIO IR Pin",
+  "GPIO_IN_DOC": "GPIO pin connected to the IR sensors signal line"
 }


### PR DESCRIPTION
Hi,

I've added a setting to allow you to set the GPIO which the IR receiver is connected to if you have a raspberry pi and the HAT hasn't already configured it.

To keep it simple you need to reboot for the setting to work.
I believe it's possible to dynamically reload the dt overlay but this would require a bit more reworking of the code

Currently no checking done on the parameter.
