### PR TITLE
Remove version in pretty name to avoid error in plugin view

### DIFF
--- a/plugins/music_service/volspotconnect2/package.json
+++ b/plugins/music_service/volspotconnect2/package.json
@@ -9,7 +9,7 @@
 	"author": "Balbuze & Ashthespy",
 	"license": "GPL 3.0",
 	"volumio_info": {
-		"prettyName": "Volumio Spotify Connect2 0.7.4",
+		"prettyName": "Volumio Spotify Connect2",
 		"icon": "fa-spotify",
 		"plugin_type": "music_service"
 	},


### PR DESCRIPTION
Remove the version number in pretty to avoid a bug in the selection of the plugin : Even if the plugin Volumio Spotify Connect2 is installed, the button "Uninstall won't never appear". The button "install" is always visible.

It's because the pretty name saved in the configuration is not the same than the package.json (comparaison failed in pluginmanager.js L.1772)