### PR TITLE
Use debounce instead of changed GPIO values

### DIFF
--- a/plugins/system_controller/gpio-buttons/index.js
+++ b/plugins/system_controller/gpio-buttons/index.js
@@ -182,7 +182,7 @@ GPIOButtons.prototype.createTriggers = function() {
 
 		if(enabled === true){
 			self.logger.info('GPIO-Buttons: '+ action + ' on pin ' + pin);
-			var j = new Gpio(pin,'in','both');
+			var j = new Gpio(pin,'in','rising', {debounceTimeout: 250});
 			j.watch(self.listener.bind(self,action));
 			self.triggers.push(j);
 		}
@@ -210,21 +210,10 @@ GPIOButtons.prototype.clearTriggers = function () {
 
 GPIOButtons.prototype.listener = function(action,err,value){
 	var self = this;
-
-	var c3 = action.concat('.value');
-	var lastvalue = self.config.get(c3);
-
-	// IF change AND high (or low?)
-	if(value !== lastvalue && value === 1){
-		//do thing
-		self[action]();
-	}
-	// remember value
-	self.config.set(c3,value);
+	
+	// we now debounce the button, so no need to check for the value
+	self[action]();
 };
-
-
-
 
 
 //Play / Pause


### PR DESCRIPTION
When using the previous version of the plugin, I was noticing that the trigger was executed only very rarely.
The reason for this seem was that the value issued from the GPIO was not always `1`. I believe it may have something to do with the button hardware I've been using.
As far as I could see, the motivation for checking the values was only trigger once the value has changed. I can only see a reason in this to debounce.
Thus, I changed the buttons to be debounced by themselves. Now, it works like a charm.

However, I'm not 100% positive about restricting it to `rising`: You need to have a proper pull-uo/down-resistor configured, as far as I can see.

Thus, I'm really looking forward to receiving feedback from somebody more knowledgable than myself 