### PR TITLE
Fix installing touch display plugin

### DIFF
--- a/plugins/miscellanea/touch_display/install.sh
+++ b/plugins/miscellanea/touch_display/install.sh
@@ -36,7 +36,7 @@ then
   if [ -f /sys/devices/platform/rpi_backlight/backlight/rpi_backlight/brightness ]; then
     echo "Installing UDEV rule adjusting backlight brightness permissions"
     sudo echo "SUBSYSTEM==\"backlight\", RUN+=\"/bin/chmod 0666 /sys/devices/platform/rpi_backlight/backlight/rpi_backlight/brightness\"" > /etc/udev/rules.d/99-backlight.rules
-    sudo udevadm control --reload-rules
+    sudo /bin/chmod 0666 /sys/devices/platform/rpi_backlight/backlight/rpi_backlight/brightness
   fi
 
 else
@@ -46,7 +46,7 @@ else
   sudo apt-get -y install
 
   echo "Installing Graphical environment"
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y xinit xorg openbox libexif12 xserver-xorg-legacy
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y xinit xorg openbox libexif12
 
   echo "Downloading Chromium"
   cd /home/volumio/

--- a/plugins/miscellanea/touch_display/package.json
+++ b/plugins/miscellanea/touch_display/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touch_display",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "The plugin enables the touch display controller for the original Raspberry 7\" touchscreen.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Removing "xserver-xorg-legacy" from the packages to be installed on non-Raspberry-Pi systems should fix the issue reported by tabularasa ([https://forum.volumio.org/touch-display-t12586.html#p66071](url)).

Also fixed: Permissions on "/sys/devices/platform/rpi_backlight/backlight/rpi_backlight/brightness" are now immediately adjusted when the plugin gets installed on Raspberry Pi (before a reboot was required).