### PR TITLE
Add XBox 360 Universal Media remote support to ir_controller plugin

### DIFF
--- a/plugins/accessory/ir_controller/configurations/XBox 360 Remote/lircd.conf
+++ b/plugins/accessory/ir_controller/configurations/XBox 360 Remote/lircd.conf
@@ -1,0 +1,85 @@
+
+# Please make this file available to others
+# by sending it to <lirc@bartelmus.de>
+#
+# this config file was automatically generated
+# using lirc-0.9.0(default) on Thu Jun  4 14:50:30 2015
+#
+# contributed by DBMandrake
+#
+# brand:                       Microsoft
+# model no. of remote control: Xbox 360 Media remote
+# devices being controlled by this remote:
+#
+
+begin remote
+
+  name  Xbox_360
+  bits           13
+  flags RC6|CONST_LENGTH
+  eps            30
+  aeps          100
+
+  header       2671   884
+  one           451   435
+  zero          451   435
+  pre_data_bits   24
+  pre_data       0x1BFF80
+  gap          106660
+#  min_repeat      1
+#  suppress_repeat 1
+#  uncomment to suppress unwanted repeats
+  toggle_bit_mask 0x8000
+  rc6_mask    0x100000000
+
+      begin codes
+          KEY_EJECTCD              0x0BD7
+#         XBOXGUIDE                0x0B9B
+          KEY_POWER                0x0BF3
+          KEY_STOP                 0x0BE6
+          KEY_PAUSE                0x0BE7
+          KEY_REWIND               0x0BEA
+          KEY_FASTFORWARD          0x0BEB
+          KEY_PREVIOUS             0x0BE4
+          KEY_NEXT                 0x0BE5
+          KEY_PLAY                 0x0BE9
+          KEY_ZOOM                 0x0BB0
+          KEY_TITLE                0x0BAE
+          KEY_MENU                 0x0BDB
+          KEY_BACK                 0x0BDC
+          KEY_INFO                 0x0BF0
+          KEY_UP                   0x0BE1
+          KEY_DOWN                 0x0BE0
+          KEY_LEFT                 0x0BDF
+          KEY_RIGHT                0x0BDE
+          KEY_OK                   0x0BDD
+          KEY_YELLOW               0x0BD9
+          KEY_BLUE                 0x0B97
+          KEY_GREEN                0x0B99
+          KEY_RED                  0x0BDA
+          KEY_VOLUMEUP             0x0BEF
+          KEY_VOLUMEDOWN           0x0BEE
+          KEY_CHANNELUP            0x0B93
+          KEY_CHANNELDOWN          0x0B92
+          KEY_MUTE                 0x0BF1
+          KEY_HOME                 0x0BF2
+          KEY_ENTER                0x0BF4
+          KEY_DELETE               0x0BF5
+          KEY_RECORD               0x0BE8
+          KEY_NUMERIC_1            0x0BFE
+          KEY_NUMERIC_2            0x0BFD
+          KEY_NUMERIC_3            0x0BFC
+          KEY_NUMERIC_4            0x0BFB
+          KEY_NUMERIC_5            0x0BFA
+          KEY_NUMERIC_6            0x0BF9
+          KEY_NUMERIC_7            0x0BF8
+          KEY_NUMERIC_8            0x0BF7
+          KEY_NUMERIC_9            0x0BF6
+          KEY_NUMERIC_STAR         0x0BE2
+          KEY_NUMERIC_0            0x0BFF
+          KEY_NUMERIC_POUND        0x0BE3
+      end codes
+
+end remote
+
+

--- a/plugins/accessory/ir_controller/configurations/XBox 360 Remote/lircrc
+++ b/plugins/accessory/ir_controller/configurations/XBox 360 Remote/lircrc
@@ -1,0 +1,57 @@
+### Playback commands ###
+begin
+prog = irexec
+button = KEY_PLAY
+config = /usr/local/bin/volumio play
+end
+begin
+prog = irexec
+button = KEY_PAUSE
+config = /usr/local/bin/volumio pause
+end
+begin
+prog = irexec
+button = KEY_STOP
+config = /usr/local/bin/volumio stop
+end
+begin
+prog = irexec
+button = KEY_PREVIOUS
+config = /usr/local/bin/volumio previous
+end
+begin
+prog = irexec
+button = KEY_NEXT
+config = /usr/local/bin/volumio next
+end
+begin
+prog = irexec
+button = KEY_FASTFORWARD
+config = /usr/local/bin/volumio seek plus
+end
+begin
+prog = irexec
+button = KEY_REWIND
+config = /usr/local/bin/volumio seek minus
+end
+begin
+prog = irexec
+button = KEY_DELETE
+config = /usr/local/bin/volumio clear
+end
+### Volume commands ###
+begin
+prog = irexec
+button = KEY_VOLUMEUP
+config = /usr/local/bin/volumio volume plus
+end
+begin
+prog = irexec
+button = KEY_VOLUMEDOWN
+config = /usr/local/bin/volumio volume minus
+end
+begin
+prog = irexec
+button = KEY_MUTE
+config = /usr/local/bin/volumio volume toggle
+end


### PR DESCRIPTION
Adds support for the Xbox 360 Universal Media remote using the lircd profile I originally created for OSMC.

Tested on a Raspberry Pi 4 with GPIO IR receiver running the current version of Volumio. Tested with both the genuine Xbox 360 Universal Media remote and the Logitech Harmony profile.
