### PR TITLE
Bugfix for touch_display plugin

### DIFF
--- a/plugins/miscellanea/touch_display/package.json
+++ b/plugins/miscellanea/touch_display/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touch_display",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "The plugin enables the touch display controller for the original Raspberry 7\" touchscreen.",
 	"main": "index.js",
 	"scripts": {
@@ -18,6 +18,6 @@
 		"fs-extra": "^8.1.0",
 		"kew": "^0.7.0",
 		"v-conf": "^1.4.2",
-		"socket.io-client": "^2.2.0"
+		"socket.io-client": "^2.3.0"
 	}
 }


### PR DESCRIPTION
The PR solves issue #385.

Also the plugin now makes use of /boot/userconfig.txt (where applicable) instead of /boot/config.txt so settings regarding screen rotation and GPU memory will be preserved on system updates.

The plugin automatically switches from using /boot/config.txt to /boot/userconfig.txt if userconfig.txt is detected. It falls back to using config.txt if userconfig.txt should be missing later on. The plugin checks for the existence of userconfig.txt whenever the plugin is starting, i.e. when the user enables the plugin or when Volumio is starting up and starts the enabled plugins.