### PR TITLE
Remotepi plugin: use /boot/userconfig.txt

### DIFF
--- a/plugins/miscellanea/remotepi/package.json
+++ b/plugins/miscellanea/remotepi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "remotepi",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "The plugin enables support for the RemotePi board.",
 	"main": "index.js",
 	"scripts": {
@@ -17,7 +17,6 @@
 		"fs-extra": "^8.1.0",
 		"kew": "^0.7.0",
 		"v-conf": "^1.4.2",
-		"onoff": "^4.1.3",
-		"sleep": "^6.1.0"
+		"onoff": "^5.0.0"
 	}
 }


### PR DESCRIPTION
The plugin now makes use of /boot/userconfig.txt (where applicable) instead of /boot/config.txt so overlay settings will be preserved on system updates.

The plugin automatically switches from using /boot/config.txt to /boot/userconfig.txt if userconfig.txt is detected. It falls back to using config.txt if userconfig.txt should be missing later on. The plugin checks for the existence of userconfig.txt whenever the plugin is starting, i.e. when the user enables the plugin or when Volumio is starting up and starts the enabled plugins. 