### PR TITLE
Fix touch display plugin when using userconfig.txt for gpu_mem

### DIFF
--- a/plugins/miscellanea/touch_display/install.sh
+++ b/plugins/miscellanea/touch_display/install.sh
@@ -34,13 +34,23 @@ then
   sudo apt-get install -y chromium-browser
 
   if [ -f /sys/devices/platform/rpi_backlight/backlight/rpi_backlight/brightness ]; then
-    echo "Installing UDEV rule adjusting backlight brightness permissions"
+    echo "Creating UDEV rule adjusting backlight brightness permissions"
     sudo echo "SUBSYSTEM==\"backlight\", RUN+=\"/bin/chmod 0666 /sys/devices/platform/rpi_backlight/backlight/rpi_backlight/brightness\"" > /etc/udev/rules.d/99-backlight.rules
     sudo /bin/chmod 0666 /sys/devices/platform/rpi_backlight/backlight/rpi_backlight/brightness
   fi
 
+  echo "Creating /etc/X11/xorg.conf.d dir"
   sudo mkdir /etc/X11/xorg.conf.d
-  sudo cp /usr/share/X11/xorg.conf.d/40-libinput.conf /etc/X11/xorg.conf.d/40-libinput.conf
+
+  echo "Creating Xorg configuration file"
+  sudo echo "# This file is managed by the Touch Display plugin: Do not alter!
+# It will be deleted when the Touch Display plugin gets uninstalled.
+Section \"InputClass\"
+        Identifier \"Touch rotation\"
+        MatchIsTouchscreen \"on\"
+        MatchDevicePath \"/dev/input/event*\"
+        MatchDriver \"libinput|evdev\"
+EndSection" > /etc/X11/xorg.conf.d/95-touch_display-plugin.conf
 
 else
 

--- a/plugins/miscellanea/touch_display/package.json
+++ b/plugins/miscellanea/touch_display/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touch_display",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "The plugin enables the touch display controller for the original Raspberry 7\" touchscreen.",
 	"main": "index.js",
 	"scripts": {

--- a/plugins/miscellanea/touch_display/uninstall.sh
+++ b/plugins/miscellanea/touch_display/uninstall.sh
@@ -8,7 +8,7 @@ sudo rm /lib/systemd/system/volumio-kiosk.service
 if [ -f /etc/udev/rules.d/99-backlight.rules ]; then
   sudo rm /etc/udev/rules.d/99-backlight.rules
 fi
-if [ -f /etc/X11/xorg.conf.d/95-touch_display-plugin.conf]; then
+if [ -f /etc/X11/xorg.conf.d/95-touch_display-plugin.conf ]; then
   sudo rm /etc/X11/xorg.conf.d/95-touch_display-plugin.conf
 fi
 

--- a/plugins/miscellanea/touch_display/uninstall.sh
+++ b/plugins/miscellanea/touch_display/uninstall.sh
@@ -8,8 +8,8 @@ sudo rm /lib/systemd/system/volumio-kiosk.service
 if [ -f /etc/udev/rules.d/99-backlight.rules ]; then
   sudo rm /etc/udev/rules.d/99-backlight.rules
 fi
-if [ -f /etc/X11/xorg.conf.d/40-libinput.conf ]; then
-  sudo rm /etc/X11/xorg.conf.d/40-libinput.conf
+if [ -f /etc/X11/xorg.conf.d/95-touch_display-plugin.conf]; then
+  sudo rm /etc/X11/xorg.conf.d/95-touch_display-plugin.conf
 fi
 
 echo "Done"


### PR DESCRIPTION
As recently discovered ([https://github.com/volumio/Build/pull/368#issuecomment-572785214](url)) gpu_mem* settings placed in /boot/userconfig.txt work only if there is no such setting in /boot/config.txt. This PR fixes this for the touch display plugin.

In order to apply touch transformation settings not only to libinput but also to evdev driven touchscreens, the plugin now uses a custom xorg configuration file "/etc/xorg.conf.d/95-touch_display-plugin.conf" instead of "/etc/xorg.conf.d/40-libinput.conf".