### PR TITLE
Upgrade to NanoSound v1.9, additional pymemcache lib needed

### DIFF
--- a/plugins/miscellanea/nanosound/install.sh
+++ b/plugins/miscellanea/nanosound/install.sh
@@ -24,6 +24,7 @@ sudo -H pip install --upgrade python-mpd2 socketIO-client
 sudo apt-get -y install libfreetype6-dev libjpeg-dev build-essential
 sudo -H pip install --upgrade setuptools
 sudo -H pip install --upgrade luma.oled
+sudo -H pip install --upgrade pymemcache
 
 #Install OLED service
 cd /tmp

--- a/plugins/miscellanea/nanosound/package.json
+++ b/plugins/miscellanea/nanosound/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nanosound",
-	"version": "1.8.3",
+	"version": "1.9.0",
 	"description": "Companion plugin for NanoSound DAC",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This is to prepare for extra upcoming functions which OLED screen of NanoSound can show the ripping status of NanoSound CD