### PR TITLE
fix for armv8 architecture

### DIFF
--- a/plugins/music_service/RoonBridge/install.sh
+++ b/plugins/music_service/RoonBridge/install.sh
@@ -24,7 +24,7 @@ case "$MACHINE_ARCH" in
             ARCH="armv7hf"
             ;;
         aarch64*)
-            ARCH="armv8"
+            ARCH="armv7hf"
             ;;
         x86_64*)
             ARCH="x64" 


### PR DESCRIPTION
As volumio's rootfs is 32bit, armv8 won't work here.