### PR TITLE
Radio Paradise plugin: Reflecting recent changes in FLAC streams

### DIFF
--- a/plugins/music_service/radio_paradise/index.js
+++ b/plugins/music_service/radio_paradise/index.js
@@ -228,18 +228,17 @@ ControllerRadioParadise.prototype.clearAddPlayTrack = function (track) {
         // Advanced stream via API
         flacUri = track.uri;
 
+        channelMix = "Main";
+        metadataUrl = "https://api.radioparadise.com/api/now_playing?chan=0";
         if (track.uri.includes("mellow")) {
             channelMix = "Mellow";
             metadataUrl = "https://api.radioparadise.com/api/now_playing?chan=1";
         } else if (track.uri.includes("rock")) {
             channelMix = "Rock";
             metadataUrl = "https://api.radioparadise.com/api/now_playing?chan=2";
-        } else if (track.uri.includes("eclectic")) {
-            channelMix = "Eclectic";
+        } else if (track.uri.includes("world")) {
+            channelMix = "World/Etc";
             metadataUrl = "https://api.radioparadise.com/api/now_playing?chan=3";
-        } else {
-            channelMix = "Main";
-            metadataUrl = "https://api.radioparadise.com/api/now_playing?chan=0"
         }
         
         var songs;

--- a/plugins/music_service/radio_paradise/radio_stations.json
+++ b/plugins/music_service/radio_paradise/radio_stations.json
@@ -18,22 +18,22 @@
       {
         "title": "Radio Paradise Main Mix (FLAC)",
         "uri": "webrp/0",
-        "url": "http://stream.radioparadise.com/flac"
+        "url": "https://stream.radioparadise.com/fb/flac"
       },
       {
         "title": "Radio Paradise Mellow Mix (FLAC)",
         "uri": "webrp/1",
-        "url": "http://stream.radioparadise.com/mellow-flac"
+        "url": "https://stream.radioparadise.com/fb/mellow-flac"
       },
       {
         "title": "Radio Paradise Rock Mix (FLAC)",
         "uri": "webrp/2",
-        "url": "http://stream.radioparadise.com/rock-flac"
+        "url": "https://stream.radioparadise.com/fb/rock-flac"
       },
       {
-        "title": "Radio Paradise Eclectic Mix (FLAC)",
+        "title": "Radio Paradise World/Etc Mix (FLAC)",
         "uri": "webrp/3",
-        "url": "http://stream.radioparadise.com/eclectic-flac"
+        "url": "https://stream.radioparadise.com/fb/world-etc-flac"
       },
       {
         "title": "Radio Paradise (AAC 320k)",

--- a/plugins/music_service/radio_paradise/radio_stations.json
+++ b/plugins/music_service/radio_paradise/radio_stations.json
@@ -18,22 +18,22 @@
       {
         "title": "Radio Paradise Main Mix (FLAC)",
         "uri": "webrp/0",
-        "url": "https://stream.radioparadise.com/fb/flac"
+        "url": "https://stream.radioparadise.com/flac"
       },
       {
         "title": "Radio Paradise Mellow Mix (FLAC)",
         "uri": "webrp/1",
-        "url": "https://stream.radioparadise.com/fb/mellow-flac"
+        "url": "https://stream.radioparadise.com/mellow-flac"
       },
       {
         "title": "Radio Paradise Rock Mix (FLAC)",
         "uri": "webrp/2",
-        "url": "https://stream.radioparadise.com/fb/rock-flac"
+        "url": "https://stream.radioparadise.com/rock-flac"
       },
       {
         "title": "Radio Paradise World/Etc Mix (FLAC)",
         "uri": "webrp/3",
-        "url": "https://stream.radioparadise.com/fb/world-etc-flac"
+        "url": "https://stream.radioparadise.com/world-etc-flac"
       },
       {
         "title": "Radio Paradise (AAC 320k)",


### PR DESCRIPTION
RP added metadata to the FLAC streams which seems to produce stability and audio issues. RP provides also FLAC without metadata. When links are modified to use those streams without metadata, sound and stability improved. We do not need in-stream metadata, as we collect them from API calls.
RP also renamed Eclectic mix to World/Etc, so this is to reflect this as well.