### PR TITLE
Adapt "prettyName" of the Touch Display plugin

### DIFF
--- a/plugins/volumio/armhf/plugins.json
+++ b/plugins/volumio/armhf/plugins.json
@@ -278,7 +278,7 @@
 			"description": "Things that cannot go in other categories",
 			"plugins": [
 				{
-					"prettyName": "Touch Display Plugin",
+					"prettyName": "Touch Display",
 					"icon": "fa-hand-pointer-o",
 					"name": "touch_display",
 					"version": "1.1.8",


### PR DESCRIPTION
Currently the "prettyName" of the Touch Display plugin differs from the entry in the plugin's [package.json](https://github.com/volumio/volumio-plugins/blob/9c4fb9fe2da97aa926a800ea2685bcdd89a5364f/plugins/miscellanea/touch_display/package.json#L12). This has the effect that the plugin is listed as installable under available plugins in the plugin manager although it has already been installed. The button next to the "Details" button remains labled "Install". Further more the plugin does not appear as updateable when a newer version of the plugin becomes available.

The commit changes "prettyName" accordingly to the entry in the package.json from "Touch Display Plugin" to simply "Touch Display". The removal of the affix "Plugin" corresponds to the pretty names of the other plugins.