### PR TITLE
v2.3.4 - Better paused track timeout handling

### DIFF
--- a/plugins/music_service/pandora/Readme.md
+++ b/plugins/music_service/pandora/Readme.md
@@ -2,11 +2,15 @@
 
 ## Getting Started
 
-### Downloading the Source Code from GitHub
-
 First you'll need to SSH to your Volumio machine.<br/>
 To enable SSH access, browse to http://volumio.local/dev and turn it on.<br/>
 <br/>
+Make sure your system clock is set properly.  This command set you up for regular clock updates:<br/>
+
+`sudo timedatectl set-ntp true`
+
+### Downloading the Source Code from GitHub
+
 Connect to your Volumio machine.<br/>
 Use PuTTY on Windows or some equivalent.<br/>
 Mac users can use a terminal window, ask a search engine for help, or visit an Apple store.<br/>
@@ -19,13 +23,13 @@ Then, clone the repository:
 
 `git clone https://github.com/truckershitch/volumio-plugins.git`<br/>
 
-### <b>Optional:</b> There are two older versions archived on GitHub:
+### <b>Optional (not recommended):</b> There are two older versions archived on GitHub
 
-If you want to try out another branch (at this point I would not bother -- Volumio has the 1.0.0 version already) change to the volumio-plugins directory:
+If you want to try out another branch, change to the `volumio-plugins` directory:
 
 `cd volumio-plugins`
 
-The pianode branch is the oldest and works the least.  I have not tested it on the newer Volumio releases.<br/>
+The pianode branch is the oldest <b>and works the least</b>.  I have not tested it on the newer Volumio releases.<br/>
 <b>It may break your system.  It probably won't work.</b><br/>
 <br/>
 To try your luck with the version based on pianode, do this:
@@ -43,19 +47,6 @@ Otherwise, just continue below (don't bother with checking out anything).  To sw
 Or you can just delete the `volumio-plugins` directory.
 
 ## Continuing with Installation
-
-### Upgrade From Older Version
-
-~~Before installing any of these plugins manually, you should uninstall any other version from the Volumio Plugin menu or by deleting the installation directories yourself.~~<br/>
-
-~~To delete the directories manually (be careful to only delete the pandora directories!):~~
-
-~~`rm -rf /data/plugins/music_service/pandora`~~<br/>
-~~`rm -rf /data/configuration/music_service/pandora`~~
-
-~~Then execute `volumio vrestart`~~
-
-My apologies on the command-line instructions.  I was just dumping the files into `/data/plugins/music_service/pandora`.  I took another look at this.<br/>
 
 <b>To upgrade from an older plugin version:</b>
 
@@ -94,6 +85,7 @@ Much was changed for version 2.x:
 * Version 2.1.0: Actual support for Pandora One high-quality streams!  I took another look at this and I'm pretty sure that Pandora One users will get 192 Kbit/s streams now.  I do not have a premium subscription so if this does not work, please tell me.  It should, though, as the Unofficial Pandora API has a JSON of a sample playlist object on their site.  Free users like me are stuck with 128 Kbit/s.
 * Version 2.1.2: Changed version number that npm didn't like (2.1.1.1).  This Readme was amended, mainly to clarify the experimental, mostly non-working, historical status of the pianode branch.  The installation steps were clarified.  A few things were fixed when the plugin closes (removing it from the Volumio Sources, stopping the track expiration loop).
 * Version 2.3.0: Optional Thumbs-Down sent to Pandora for a track skipped by the Next media button.  The track is also removed from the queue like the sad thing it is.  Flip the switch in the plugin settings and kick the lame tracks to the curb!
+* Version 2.3.4: Pausing a stream for too long will cause a timeout.  The plugin will detect this now and skip to the next track.  Curiously, this took a bit of work to implement.
 
 ## Issues
 
@@ -106,15 +98,17 @@ After that, the functions defined for previous and next in the plugin worked fin
 * It may be possible to add a station with the Volumio search function.  I am looking into it.  The functionaliy is there.
 * Volumio has a consume mode.  As far as I can tell, it only removes the last track in the queue when any track in the queue has been played (i.e. it can remove the wrong track).<br/>
 I made my own consume function that removes the last track played no matter where it is in the queue.  I'm not sure if I have reinvented the wheel; Volumio might already be able to do this.  For now, my consume function does the job.
+* The wrapper to the JSON Pandora API I am using is not set up to use the regular Pandora One server.  The other credentials can be passed in but the module hardcodes the server URL.  This might not matter, but I haven't been able to test it.<br/>
+My alpha fork of the module is rewritten to use Promises instead of callbacks, and the server is fixed.  However, it's not ready yet.
 
-All testers are welcome, even if they ride motorcycles.  You know who you are.
+## All testers are welcome, even if they ride motorcycles.  You know who you are.
 
 ## Built with
 
 * VS Code for debugging and coding.  I can't get over how good this editor is.
 * vim for basic editing.  There is a lot of power in this humble editor.  You just have to believe....
 
-## Acknowledgments
+## Acknowledgements
 
 * Michelangelo and the other Volumio developers.
 * lostmyshape gave me the heads-up about the Unofficial Pandora API and gave me some constructive ideas.  He was the first person to look at my code and give me help.  I also borrowed his mpd player listener callback function which really helped a lot.  Much obliged!

--- a/plugins/music_service/pandora/index.js
+++ b/plugins/music_service/pandora/index.js
@@ -9,6 +9,7 @@ var execSync = require('child_process').execSync;
 
 var dnsSync = require('dns-sync');
 var anesidora = require('anesidora');
+var wget = require('node-wget-promise');
 
 const { defer, setNextTickFunction } = require('kew');
 const { REFUSED, SERVFAIL } = require('dns');
@@ -69,6 +70,7 @@ ControllerPandora.prototype.onStop = function () {
     var self = this;
 
     if (self.expireHandler) self.expireHandler.stop();
+    if (self.streamLifeChecker) self.streamLifeChecker.stop();
 
     return self.flushPandora()
         .then(() => self.stop())
@@ -447,6 +449,12 @@ ControllerPandora.prototype.clearAddPlayTrack = function (track) {
     // Here we go! (¡Juana's Adicción!)
     return self.mpdPlugin.clear()
         .then(() => {
+            if (self.streamLifeChecker) {
+                return self.streamLifeChecker.stop();
+            }
+            return libQ.resolve();
+        })
+        .then(() => {
             if (self.lastUri !== track.uri) {
                 self.removeTrack(self.lastUri);
             }
@@ -525,6 +533,7 @@ ControllerPandora.prototype.pause = function () {
     self.announceFn('pause');
 
     self.mpdPlugin.clientMpd.removeAllListeners('system-player');
+    if (self.streamLifeChecker) self.streamLifeChecker.stop();
 
     return self.mpdPlugin.pause()
         .then(() => {
@@ -542,8 +551,9 @@ ControllerPandora.prototype.resume = function () {
 
     self.mpdPlugin.clientMpd.removeAllListeners('system-player');
     self.mpdPlugin.clientMpd.once('system-player', self.pandoraListener.bind(self));
+    self.streamLifeChecker = new StreamLifeChecker(self);
 
-    return self.mpdPlugin.sendMpdCommand('play', []);
+    return self.mpdPlugin.resume();
         // .then(() => self.mpdPlugin.getState())
         // .then(state => self.pushState(state));
 };
@@ -607,10 +617,15 @@ ControllerPandora.prototype.goPreviousNext = function (fnName) {
                     }
                     return self.stop();
                 }
-                else { // 'skip' (bad uri lookup -- play next track or track 0)
-                    qPos = (qPos + 1) % qLen;
-                    self.commandRouter.stateMachine.currentPosition = qPos;
-                    return self.clearAddPlayTrack(self.getQueue()[qPos]);
+                else { // 'skip' (bad uri lookup)
+                    if (self.commandRouter.stateMachine.currentRandom !== true) {
+                        qPos = (qPos + 1) % qLen; // play next track or track 0
+                        self.commandRouter.stateMachine.currentPosition = qPos;
+                        return self.clearAddPlayTrack(self.getQueue()[qPos]);
+                    }
+                    else { // next random track
+                        return self.stop();
+                    }
                 }
             }
             return libQ.resolve();
@@ -768,6 +783,7 @@ function ExpireOldTracks (self, interval) {
 
     ExpireOldTracks.prototype.stop = function () {
         clearInterval(reaperID);
+        return libQ.resolve();
     };
 
     ExpireOldTracks.prototype.reaper = function () {
@@ -805,6 +821,55 @@ function ExpireOldTracks (self, interval) {
         }
 
         hangman();
+    };
+
+    this.init();
+}
+
+function StreamLifeChecker(self) {
+    var checkerID;
+    var lastSeek;
+    var interval = 5000;
+    var fnName = 'StreamLifeChecker';
+
+    StreamLifeChecker.prototype.init = function () {
+        var that = this;
+        lastSeek = self.commandRouter.stateMachine.currentSeek;
+
+        self.announceFn(fnName);
+
+        checkerID = setInterval(() => {
+            that.heartMonitor();
+        }, interval);
+    };
+
+    StreamLifeChecker.prototype.stop = function () {
+        self.logInfo(fnName + ' stopping');
+        
+        clearInterval(checkerID);
+        return libQ.resolve();
+    };
+
+    StreamLifeChecker.prototype.heartMonitor = function () {
+        var that = this;
+        let subFnName = fnName + '::heartMonitor';
+
+        self.mpdPlugin.getState()
+            .then(state => {
+                if (state.status !== 'pause') {
+                    if (state.seek == lastSeek) {
+                        let track = self.getQueueTrack();
+                        let msg = track.name + ' by ' + track.artist +
+                            ' timed out.  Advancing track';
+                        self.commandRouter.pushToastMessage('info', 'Pandora', msg);
+                        self.logInfo(subFnName + ': ' + msg);
+                        return self.goPreviousNext('skip')
+                            .then(() => self.removeTrack(track.uri))
+                            .then(() => that.stop());
+                    }
+                }
+                lastSeek = state.seek;
+            });
     };
 
     this.init();

--- a/plugins/music_service/pandora/package.json
+++ b/plugins/music_service/pandora/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pandora",
-	"version": "2.3.3",
+	"version": "2.3.4",
 	"description": "A plugin to access Pandora Web Radio",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
v2.3.4 update:  I thought I fixed this before!

If a stream is paused too long, the stream ends and mpd gets stuck in the 'play' status.  An interval timer queries the mpd seek value every five seconds when the track resumes.  If it doesn't change, the track is removed and the next one, random or otherwise, starts.