### PR TITLE
v2.5.1 removeOldTrackBlock() removed setTimeout()

### DIFF
--- a/plugins/music_service/pandora/index.js
+++ b/plugins/music_service/pandora/index.js
@@ -398,13 +398,18 @@ ControllerPandora.prototype.appendTracksToMpd = function (newTracks) {
     return defer.promise;
 };
 
-ControllerPandora.prototype.removeTrack = function (uri) {
+ControllerPandora.prototype.removeTrack = function (trackUri) {
     var self = this;
+    const fnName = 'removeTrack';
+    let curUri = self.getQueueTrack().uri;
 
-    self.announceFn('removeTrack');
+    self.announceFn(fnName + ': ' + trackUri);
 
-    if (uri !== null) {
-       self.commandRouter.stateMachine.removeQueueItem({value: self.getQueueIndex(uri)});
+    if (trackUri !== null && trackUri !== curUri) {
+        self.commandRouter.stateMachine.removeQueueItem({value: self.getQueueIndex(trackUri)});
+    }
+    else {
+        self.logInfo(fnName + ': '+ 'Not removing ' + trackUri);
     }
     return libQ.resolve();
 };
@@ -439,11 +444,16 @@ ControllerPandora.prototype.removeOldTrackBlock = function (pQPos, pandoraQ) {
 
     self.announceFn('removeOldTrackBlock');
 
+    // for (let i = 0; i < limit; i++) {
+    //     setTimeout(() => {
+    //         self.removeTrack(pandoraQ[i].uri);
+    //     }, 10000 * (i + 1));
+    // }
+    
     for (let i = 0; i < limit; i++) {
-        setTimeout(() => {
-            self.removeTrack(pandoraQ[i].uri);
-        }, 10000 * i);
+        self.removeTrack(pandoraQ[i].uri);
     }
+
     return libQ.resolve();
 };
 

--- a/plugins/music_service/pandora/package.json
+++ b/plugins/music_service/pandora/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pandora",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"description": "A plugin to access Pandora Web Radio",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
v2.5.1 Update

Removed setTimeout loop from removeOldTrackBlock() -- The tracks were being removed, but if the user selected a track that was set to be deleted, the loop would fire off again, and the tracks to be deleted by the function would have already been deleted.  

I may readdress this.  I don't like deleting several tracks at one time. I want to push this fix first before I change things.