### PR TITLE
Hotfix/crash fix podcast

### DIFF
--- a/plugins/music_service/podcast/index.js
+++ b/plugins/music_service/podcast/index.js
@@ -318,13 +318,19 @@ ControllerPodcast.prototype.handleBrowseUri = function (curUri) {
         response = self.getPodcastBBC(uriParts[2]);
       else if (uriParts.length === 4)
         response = self.getPodcastBBCEpisodes(uriParts[2], uriParts[3]);
+      else
+        response = libQ.reject();
     }
     else {
       response = self.getPodcastContent(curUri);
     }
   }
 
-  return response;
+  return response
+    .fail(function (e) {
+      self.logger.info('[' + Date.now() + '] ' + '[podcast] handleBrowseUri failed');
+      libQ.reject(new Error());
+    });
 };
 
 ControllerPodcast.prototype.getRootContent = function() {
@@ -628,6 +634,11 @@ ControllerPodcast.prototype.explodeUri = function (uri) {
   switch (uris[1]) {
     case 'bbc':
       // podcast/bbc/station/channel/index
+      if (uris.length < 5) {
+        response = libQ.reject();
+        return response;
+      }
+
       episode = self.currentEpisodes[uris[4]];
       response = {
         service: self.serviceName,
@@ -642,6 +653,11 @@ ControllerPodcast.prototype.explodeUri = function (uri) {
 
     default:
       // podcast/channel/index
+      if (uris.length < 3) {
+        response = libQ.reject();
+        return response;
+      }
+
       episode = self.currentEpisodes[uris[2]];
       response = {
         service: self.serviceName,

--- a/plugins/music_service/podcast/package.json
+++ b/plugins/music_service/podcast/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "podcast",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Podcast for Volumio2",
 	"main": "index.js",
 	"scripts": {
@@ -18,8 +18,8 @@
 		"v-conf": "^1.4.2",
 		"fs-extra": "^8.1.0",
 		"kew": "^0.7.0",
-		"rss-parser": "^3.7.2",
-		"lodash": "^4.17.15",
+		"rss-parser": "^3.9.0",
+		"lodash": "^4.17.20",
 		"unirest": "^0.6.0",
 		"cheerio": "^1.0.0-rc.3"
 	},

--- a/plugins/music_service/podcast/podcasts_list.json
+++ b/plugins/music_service/podcast/podcasts_list.json
@@ -18,7 +18,7 @@
       "id": "u1obuqbc20o9ms2v",
       "title": "Anderson Cooper 360",
       "url": "http://feeds.adknit.com/app-search/cnn/anderson-cooper-360/all/1080/200",
-      "image": "http://pg-act-11-o.s3-us-west-2.amazonaws.com/11/artwork/show.3.audioart.original.jpg"
+      "image": "https://www.omnycontent.com/d/playlist/d83f52e4-2455-47f4-982e-ab790120b954/a6c57f01-d29f-4556-be4b-ab86002f5bc5/f3bbd658-5edf-479a-9aa7-ab86002f5bd7/image.jpg"
     }
   ],
   "bbc": [


### PR DESCRIPTION
As I told before, I upload podcast PR only. Podcast plugin crash bug fix whenever user try to click directory icon and update package components.

- podcast crash when all items in a directory are added
- change Anderson cooper 360 podcast image url
- package component version update

Thanks.