### PR TITLE
Pandora Plugin v2.5.2 update - Fix idle authorization timeout

### DIFF
--- a/plugins/music_service/pandora/package.json
+++ b/plugins/music_service/pandora/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pandora",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"description": "A plugin to access Pandora Web Radio",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Just a minor refactor.  Credentials are refreshed every three hours when plugin is running regardless of activity.  User no longer has to unload and reload the plugin to resume playback.

Works for me and another in the forum.