### PR TITLE
Virtual Keyboard plugin: Fix triggering race condition in Touch Display plugin

### DIFF
--- a/plugins/miscellanea/virtual_keyboard/UIConfig.json
+++ b/plugins/miscellanea/virtual_keyboard/UIConfig.json
@@ -7,7 +7,7 @@
                 "id": "vkbd_conf",
                 "element": "section",
                 "label": "TRANSLATE.VKBD.VKBD_CONF",
-                "icon": "fa-plug",
+                "icon": "fa-language",
                 "onSave": {"type":"controller", "endpoint":"miscellanea/virtual_keyboard", "method":"saveConf"},
                 "saveButton": {
                               "label": "TRANSLATE.VKBD.SAVE",

--- a/plugins/miscellanea/virtual_keyboard/index.js
+++ b/plugins/miscellanea/virtual_keyboard/index.js
@@ -39,7 +39,7 @@ VirtualKeyboard.prototype.onVolumioShutdown = function () {
 VirtualKeyboard.prototype.onVolumioReboot = function () {
   if (mbkbd !== undefined) {
     mbkbd.removeAllListeners();
-  };
+  }
   return libQ.resolve();
 };
 
@@ -228,14 +228,10 @@ VirtualKeyboard.prototype.reconfigure = function (action) {
         if (self.hasTouchDisplay(true)) {
           self.commandRouter.pushToastMessage('info', self.commandRouter.getI18nString('VKBD.PLUGIN_NAME'), self.commandRouter.getI18nString('VKBD.RESTART_VOLUMIOKIOSK_MSG'));
           setTimeout(function () {
-            cp.exec('/usr/bin/sudo /bin/systemctl restart volumio-kiosk.service', { uid: 1000, gid: 1000 }, function (error, stdout, stderr) {
-              if (error !== null) {
-                self.logger.error(id + 'Failed to restart volumio-kiosk.service: ' + error);
-                self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('VKBD.PLUGIN_NAME'), self.commandRouter.getI18nString('VKBD.ERR_RESTART') + 'volumio-kiosk.service: ' + error);
-              } else {
-                self.logger.info(id + 'systemctl restart volumio-kiosk.service succeeded.');
-              }
-            });
+            self.commandRouter.executeOnPlugin('miscellanea', 'touch_display', 'onStop', '')
+              .then(function () {
+                self.commandRouter.executeOnPlugin('miscellanea', 'touch_display', 'onStart', '');
+              });
           }, 3000);
         }
         defer.resolve();
@@ -260,7 +256,7 @@ VirtualKeyboard.prototype.reconfigure = function (action) {
           } else {
             stdout = stdout.slice(stdout.indexOf(' xinit '));
             stdout = stdout.slice(stdout.search(/:[0-9]+ |:[0-9]+\.[0-9]+ /) + 1, stdout.search(os.EOL));
-            const displayNumber = stdout.slice(0, stdout.search(/ |\.[0-9]+ /));
+            const displayNumber = stdout.slice(0, stdout.search(/ |\.[0-9]+ /)).toString();
             try {
               mbkbd = cp.spawn('matchbox-keyboard', ['-d'], { env: { ...process.env, DISPLAY: ':' + displayNumber, MB_KBD_CONFIG: '/data/configuration/miscellanea/virtual_keyboard/keyboard.xml' }, uid: 1000, gid: 1000 })
                 .on('error', function (error) {

--- a/plugins/miscellanea/virtual_keyboard/package.json
+++ b/plugins/miscellanea/virtual_keyboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtual_keyboard",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "The plugin installs a virtual keyboard. It requires the Touch Display plugin to be installed.",
 	"main": "index.js",
 	"scripts": {

--- a/plugins/miscellanea/virtual_keyboard/uninstall.sh
+++ b/plugins/miscellanea/virtual_keyboard/uninstall.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-echo "Uninstalling Virtual Keyboard dependencies"
+echo "Uninstalling Virtual Keyboard plugin"
 
-echo "Removing Matchbox window manager and Matchbox keyboard"
+echo "Removing dependencies"
 sudo apt-get -y purge --auto-remove matchbox-window-manager matchbox-keyboard
 
 echo "Done"


### PR DESCRIPTION
In cases where the window manager gets switched between openbox and matchbox-window-manager the function "reconfigure" now stops and restarts the Touch Display plugin itself instead of only restarting volumio-kiosk.service. This should fix triggering a race condition in the Touch Display plugin that resulted in losing screensaver settings applied by the Touch Display plugin.

**Note:** PR #486 needs to be merged before / simultaneously with this PR.