### PR TITLE
Virtual Keyboard plugin: Revised layouts

### DIFF
--- a/plugins/miscellanea/virtual_keyboard/layouts/English - UK/keyboard.xml
+++ b/plugins/miscellanea/virtual_keyboard/layouts/English - UK/keyboard.xml
@@ -67,7 +67,7 @@ UK standard keyboard layout
       </key>
       <key width="3000">
         <default display="&#9003;" action="backspace" />
-        <mod3    display="Entf" action="delete" />
+        <mod3    display="Del" action="delete" />
       </key>
       <space width="500" extended="true" />
       <key extended="true">

--- a/plugins/miscellanea/virtual_keyboard/layouts/English - US/keyboard.xml
+++ b/plugins/miscellanea/virtual_keyboard/layouts/English - US/keyboard.xml
@@ -65,7 +65,7 @@ US standard keyboard layout
       </key>
       <key width="4000">
         <default display="&#9003;" action="backspace" />
-        <mod3    display="Entf" action="delete" />
+        <mod3    display="Del" action="delete" />
       </key>
       <space width="500" extended="true" />
       <key extended="true">
@@ -201,7 +201,7 @@ US standard keyboard layout
         <default display="'" />
         <shifted display='"' />
       </key>
-      <key width="4800"> <!-- width ok???? -->
+      <key width="4800">
         <default display="" action="" />
         <mod3    display="End" action="end" />
       </key>
@@ -214,7 +214,7 @@ US standard keyboard layout
 
     <row>
       <space width="500" extended="true" />
-      <key width="3800"> <!-- width ok???? -->
+      <key width="3800">
         <default display="Shift" action="modifier:shift" />
       </key>
       <key obey-caps="true">

--- a/plugins/miscellanea/virtual_keyboard/layouts/Français/keyboard.xml
+++ b/plugins/miscellanea/virtual_keyboard/layouts/Français/keyboard.xml
@@ -2,385 +2,333 @@
 <keyboard>
 
 <!--
-
- US keyboard layout by Matt Reimer <mreimer@vpop.net>
- Passage en AZERTY par Jean-Jacques
-
+FR standard keyboard layout
 -->
 
-<options>
-<!-- not yet implemented -->
-</options>
+  <options>
+  </options>
 
-<layout id="default keyboard">
+  <layout id="default keyboard">
+    <row>
+      <space width="500" extended="true" />
+      <key>
+        <default display="²" />
+      </key>
+      <key>
+        <default display="&amp;" />
+        <shifted display="1" />
+      </key>
+      <key>
+        <default display="é" />
+        <shifted display='2' />
+        <mod1    display="~" />
+      </key>
+      <key>
+        <default display='"' />
+        <shifted display="3" />
+        <mod1    display="#" />
+      </key>
+      <key>
+        <default display="'" />
+        <shifted display="4" />
+        <mod1    display="{" />
+      </key>
+      <key>
+        <default display="(" />
+        <shifted display="5" />
+        <mod1    display="[" />
+      </key>
+      <key>
+        <default display="-" />
+        <shifted display="6" />
+        <mod1    display="|" />
+      </key>
+      <key>
+        <default display="è" />
+        <shifted display="7" />
+        <mod1    display="&#180;" />
+      </key>
+      <key>
+        <default display="_" />
+        <shifted display="8" />
+        <mod1    display="\" />
+      </key>
+      <key>
+        <default display="ç" />
+        <shifted display="9" />
+        <mod1    display="^" />
+      </key>
+      <key>
+        <default display="à" />
+        <shifted display="0" />
+        <mod1    display="@" />
+      </key>
+      <key>
+        <default display=")" />
+        <shifted display="°" />
+        <mod1    display="]" />
+      </key>
+      <key>
+        <default display="=" />
+        <shifted display="+" />
+        <mod1    display="}" />
+      </key>
+      <key width="3000">
+        <default display="&#9003;" action="backspace" />
+        <mod3    display="Del" action="delete" />
+      </key>
+      <space width="500" extended="true" />
+      <key extended="true">
+        <default display="Esc" action="escape" />
+      </key>
+      <key extended="true">
+        <default display="Pos1" action="home" />
+      </key>
+      <key extended="true">
+        <default display="Bild &#8593;" action="pageup" />
+      </key>
+      <space width="500" extended="true" />
+    </row>
 
-<!--
-  <row>
-     <key>
-	  <default display="ヂ" />                
-    </key>
-    <key>
-	  <default display="Ӫ" />                
-    </key>
-    <key width="1500">
-	  <default display="Ω" />                
-    </key>
-    <space width="1500" />
-    <key fill="true">
-	  <default display="⠿" />                
-    </key>
-  </row>
--->
+    <row>
+      <space width="500" extended="true" />
+      <key width="2000">
+        <default display="" action="" />
+        <mod3    display="Esc" action="escape" />
+      </key>
+      <key obey-caps="true">
+        <default display="a" />
+        <shifted display="A" />
+      </key>
+      <key obey-caps="true">
+        <default display="z" />
+        <shifted display="Z" />
+      </key>
+      <key obey-caps="true">
+        <default display="e" />
+        <shifted display="E" />
+        <mod1    display="&#8364;" />
+      </key>
+      <key obey-caps="true">
+        <default display="r" />
+        <shifted display="R" />
+      </key>
+      <key obey-caps="true">
+        <default display="t" />
+        <shifted display="T" />
+      </key>
+      <key obey-caps="true">
+        <default display="y" />
+        <shifted display="Y" />
+      </key>
+      <key obey-caps="true">
+        <default display="u" />
+        <shifted display="U" />
+      </key>
+      <key obey-caps="true">
+        <default display="i" />
+        <shifted display="I" />
+      </key>
+      <key obey-caps="true">
+        <default display="o" />
+        <shifted display="O" />
+      </key>
+      <key obey-caps="true">
+        <default display="p" />
+        <shifted display="P" />
+      </key>
+      <key obey-caps="true">
+        <default display="^" />
+        <shifted display="¨" />
+      </key>
+      <key>
+        <default display="$" />
+        <shifted display="£" />
+    	  <mod1    display="¤" />
+      </key>
+      <key width="2000">
+        <default display="" action="" />
+        <mod3    display="Pos1" action="home" />
+      </key>
+      <space width="500" extended="true" />
+      <key extended="true">
+        <default display="Del" action="delete" />
+      </key>
+      <key extended="true">
+        <default display="End" action="end" />
+      </key>
+      <key extended="true">
+        <default display="PgDn" action="pagedown" />
+      </key>
+      <space width="500" extended="true" />
+    </row>
 
-  <row>
+    <row>
+      <space width="500" extended="true" />
+      <key width="2600">
+        <default display="Caps" action="modifier:caps" />
+      </key>
+      <key obey-caps="true">
+        <default display="q" />
+        <shifted display="Q" />
+      </key>
+      <key obey-caps="true">
+        <default display="s" />
+        <shifted display="S" />
+      </key>
+      <key obey-caps="true">
+        <default display="d" />
+        <shifted display="D" />
+      </key>
+      <key obey-caps="true">
+        <default display="f" />
+        <shifted display="F" />
+      </key>
+      <key obey-caps="true">
+        <default display="g" />
+        <shifted display="G" />
+      </key>
+      <key obey-caps="true">
+        <default display="h" />
+        <shifted display="H" />
+      </key>
+      <key obey-caps="true">
+        <default display="j" />
+        <shifted display="J" />
+      </key>
+      <key obey-caps="true">
+        <default display="k" />
+        <shifted display="K" />
+      </key>
+      <key obey-caps="true">
+        <default display="l" />
+        <shifted display="L" />
+      </key>
+      <key obey-caps="true">
+        <default display="m" />
+        <shifted display="M" />
+      </key>
+      <key obey-caps="true">
+        <default display="ù" />
+        <shifted display="%" />
+      </key>
+      <key>
+        <default display="*" />
+        <shifted display="µ" />
+      </key>
+      <key width="1500">
+        <default display="" action="" />
+        <mod3    display="End" action="end" />
+      </key>
+      <space width="500" extended="true" />
+      <space width="1000" extended="true" />
+      <space width="1000" extended="true" />
+      <space width="1000" extended="true" />
+      <space width="500" extended="true" />
+    </row>
 
-    <space width="500" extended="true"/>
+    <row>
+      <space width="500" extended="true" />
+      <key width="1400">
+        <default display="Shift" action="modifier:shift" />
+      </key>
+      <key>
+        <default display="&#60;" />
+        <shifted display="&#63;" />
+      </key>
+      <key obey-caps="true">
+        <default display="w" />
+        <shifted display="W" />
+      </key>
+      <key obey-caps="true">
+        <default display="x" />
+        <shifted display="X" />
+      </key>
+      <key obey-caps="true">
+        <default display="c" />
+        <shifted display="C" />
+      </key>
+      <key obey-caps="true">
+        <default display="v" />
+        <shifted display="V" />
+      </key>
+      <key obey-caps="true">
+        <default display="b" />
+        <shifted display="B" />
+      </key>
+      <key obey-caps="true">
+        <default display="n" />
+        <shifted display="N" />
+      </key>
+      <key>
+        <default display="," />
+        <shifted display="?" />
+      </key>
+      <key>
+        <default display=";" />
+        <shifted display="." />
+      </key>
+      <key>
+        <default display=":" />
+        <shifted display="/" />
+      </key>
+      <key>
+        <default display="!" />
+        <shifted display="§" />
+      </key>
+      <key width="4900">
+        <default display="Shift" action="modifier:shift" />
+        <mod3    display="&#8593;" action="up" />
+      </key>
+      <space width="500" extended="true" />
+      <space width="1000" extended="true" />
+      <key extended="true">
+        <default display="&#8593;" action="up" />
+      </key>
+      <space width="1000" extended="true" />
+      <space width="500" extended="true" />
+    </row>
 
-    <key fill="true">
-	  <default display="Esc" action="escape" />
-    </key>
-    <key>
-	  <default display="²" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="&amp;" />                
-	  <shifted display="1" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="é" />                
-	  <shifted display='2' />
-          <mod1    display="~" />
-    </key>
-    <key obey-caps='true'>
-	  <default display='"' />
-	  <shifted display="3" />
-          <mod1    display="#" />               
-    </key>
-    <key obey-caps='true'>
-	  <default display="'" />
-	  <shifted display="4" />                
-          <mod1    display="{" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="(" />
-	  <shifted display="5" />                
-	  <mod1    display="[" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="-" />
-	  <shifted display="6" />                
-	  <mod1    display="|" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="è" />
-	  <shifted display="7" />                
-	  <mod1    display="`" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="_" />
-	  <shifted display="8" />                
-	  <mod1    display="\" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="ç" />
-	  <shifted display="9" />                
-	  <mod1    display="^" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="à" />
-	  <shifted display="0" />                
-	  <mod1    display="@" />
-    </key>
-    <key>
-	  <default display=")" />
-	  <shifted display="°" />                
-	  <mod1    display="]" />
-    </key>
-    <key>
-	  <default display="=" />
-	  <shifted display="+" />                
-	  <mod1    display="}" />
-    </key>
-
-    <key fill="true">
-	  <default display="Bksp" action="backspace"/>
-    </key>
-
-    <space width="500" extended="true"/>
-
-    <key width="4000"  extended="true">
-	  <default display="Home" action="home"/>
-    </key>
-    <key width="4000"  extended="true">
-	  <default display="PgUp" action="pageup"/>
-    </key>
-
-    <space width="500" extended="true"/>
-
-
-  </row>
-
-  <row>
-
-    <space width="500" extended="true"/>
-
-    <key fill="true">
-	  <default display="Tab" action="tab"/>                
-    </key>
-    <key obey-caps='true'>
-	  <default display="a" />                
-	  <shifted display="A" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="z" />                
-	  <shifted display="Z" />
-    </key>
-    <key obey-caps='true'>
-	  <mod1 display="€" />
-	  <default    display="e" />                
-	  <shifted display="E" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="r" />                
-	  <shifted display="R" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="t" />                
-	  <shifted display="T" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="y" />                
-	  <shifted display="Y" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="u" />                
-	  <shifted display="U" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="i" />                
-	  <shifted display="I" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="o" />                
-	  <shifted display="O" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="p" />                
-	  <shifted display="P" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="^" />                
-	  <shifted display="¨" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="$" />                
-	  <shifted display="£" />
-	  <mod1    display="¤" />
-    </key>
-   <key obey-caps='true'>
-	  <default display="*" />                
-	  <shifted display="µ" />
-    </key>
-
-    <space width="500" extended="true"/>
-
-    <key width="4000"  extended="true">
-	  <default display="End" action="end"/>
-    </key>
-    <key width="4000"  extended="true">
-	  <default display="PgDn" action="pagedown"/>
-    </key>
-
-    <space width="500" extended="true"/>
-
-  </row>
-  <row>
-
-    <space width="500" extended="true"/>
-
-    <key fill="true">
-	  <default display="Caps" action="modifier:caps"/>                
-    </key>
-    <key obey-caps='true'>
-	  <default display="q" />                
-	  <shifted display="Q" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="s" />                
-	  <shifted display="S" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="d" />                
-	  <shifted display="D" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="f" />                
-	  <shifted display="F" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="g" />                
-	  <shifted display="G" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="h" />                
-	  <shifted display="H" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="j" />                
-	  <shifted display="J" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="k" />                
-	  <shifted display="K" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="l" />                
-	  <shifted display="L" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="m" />                
-	  <shifted display="M" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="ù" />                
-	  <shifted display='%' />
-    </key>
-    <key fill="true">
-	  <default display="Ret" action="return"/>
-    </key>
-
-    <space width="500" extended="true"/>
-
-    <space width="4000"  extended="true" />
-
-    <space width="4000"  extended="true" />
-
-    <space width="500" extended="true"/>
-
-
-  </row>
-  <row>
-
-    <space width="500" extended="true"/>
-
-    <key fill="true">
-	  <default display="Shift" action="modifier:shift"/>                
-    </key>
-
-   <key obey-caps='true'>
-          <default display="&lt;" />
-          <shifted display="&gt;" />
-    </key>
-
-    <key obey-caps='true'>
-	  <default display="w" />                
-	  <shifted display="W" />
-    </key>
-
-    <key obey-caps='true'>
-	  <default display="x" />                
-	  <shifted display="X" />
-    </key>
-
-    <key obey-caps='true'>
-	  <default display="c" />                
-	  <shifted display="C" />
-    </key>
-
-    <key obey-caps='true'>
-	  <default display="v" />                
-	  <shifted display="V" />
-    </key>
-
-    <key obey-caps='true'>
-	  <default display="b" />                
-	  <shifted display="B" />
-    </key>
-
-    <key obey-caps='true'>
-	  <default display="n" />                
-	  <shifted display="N" />
-    </key>
-
-    <key obey-caps='true'>
-	  <default display="," />                
-	  <shifted display="?" />
-    </key>
-
-    <key obey-caps='true'>
-	  <default display=";" />                
-	  <shifted display="." />
-    </key>
-    <key obey-caps='true'>
-	  <default display=":" />                
-	  <shifted display="/" />
-    </key>
-    <key obey-caps='true'>
-	  <default display="!" />                
-	  <shifted display="§" />
-    </key>
-
-
-    <key fill="true">
-	  <default display="Shift" action="modifier:shift"/>                
-    </key>
-
-    <space width="500" extended="true"/>
-
-    <space width="4000"  extended="true" />
-
-    <space width="4000"  extended="true" />
-
-    <space width="500" extended="true"/>
-
-
-
- </row>
-  <row>
-
-    <space width="500" extended="true"/>
-
-    <key>
-	  <default display="äëö" action="modifier:mod1"/>                
-    </key>
-
-    <key fill="true">
-	  <default display="Ctrl" action="modifier:ctrl"/>                
-    </key>
-
-    <key>
-	  <default display="Alt" action="modifier:alt"/>                
-    </key>
-
-
-    <key width="12000">
-	  <default display=" " action="space" />                
-    </key>
-
-    <key>
-	  <default display="up" action="up" />                
-    </key>
-    <key>
-	  <default display="dn" action="down" />                
-    </key>
-    <key>
-	  <default display="&lt;-" action="left" />                
-    </key>
-    <key>
-	  <default display="-&gt;" action="right" />                
-    </key>
-
-    <space width="500" extended="true"/>
-
-    <space width="4000"  extended="true" />
-
-    <space width="4000"  extended="true" />
-
-    <space width="500" extended="true"/>
-
-</row>
-
-</layout>
-
-
+    <row>
+      <space width="500" extended="true" />
+      <key width="2000">
+        <default display="Ctrl" action="modifier:ctrl" />
+      </key>
+      <key>
+        <default display="&#9776;" action="modifier:mod3" />
+      </key>
+      <key width="2000">
+        <default display="Alt" action="modifier:alt" />
+      </key>
+      <key width="13200">
+        <default display=" " action="space" />
+      </key>
+      <key width="2000">
+        <default display="AltGr" action="modifier:mod1" />
+      </key>
+      <key>
+        <default display="" action="" />
+        <mod3    display="&#8592;" action="left" />
+      </key>
+      <key>
+        <default display="" action="" />
+        <mod3    display="&#8595;" action="down" />
+      </key>
+      <key width="2000">
+        <default display="Ctrl" action="modifier:ctrl" />
+        <mod3    display="&#8594;" action="right" />
+      </key>
+      <space width="500" extended="true" />
+      <key extended="true">
+        <default display="&#8592;" action="left" />
+      </key>
+      <key extended="true">
+        <default display="&#8595;" action="down" />
+      </key>
+      <key extended="true">
+        <default display="&#8594;" action="right" />
+      </key>
+      <space width="500" extended="true" />
+    </row>
+  </layout>
 </keyboard>

--- a/plugins/miscellanea/virtual_keyboard/layouts/Suomi/keyboard.xml
+++ b/plugins/miscellanea/virtual_keyboard/layouts/Suomi/keyboard.xml
@@ -86,7 +86,7 @@ FI SFS 5966 multilingual keyboard layout
       </key>
       <key width="3000">
         <default display="&#9003;" action="backspace" />
-        <mod3    display="Entf" action="delete" />
+        <mod3    display="Del" action="delete" />
       </key>
       <space width="500" extended="true" />
       <key extended="true">

--- a/plugins/miscellanea/virtual_keyboard/layouts/Русский/keyboard.xml
+++ b/plugins/miscellanea/virtual_keyboard/layouts/Русский/keyboard.xml
@@ -64,7 +64,7 @@ RU standard keyboard layout
       </key>
       <key width="3000">
         <default display="&#9003;" action="backspace" />
-        <mod3    display="Entf" action="delete" />
+        <mod3    display="Del" action="delete" />
       </key>
       <space width="500" extended="true" />
       <key extended="true">
@@ -200,7 +200,7 @@ RU standard keyboard layout
         <default display="э" />
         <shifted display="Э" />
       </key>
-      <key width="3600"> <!-- width ok???? -->
+      <key width="3600">
         <default display="" action="" />
         <mod3    display="End" action="end" />
       </key>

--- a/plugins/miscellanea/virtual_keyboard/package.json
+++ b/plugins/miscellanea/virtual_keyboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtual_keyboard",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "The plugin installs a virtual keyboard. It requires the Touch Display plugin to be installed.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Mainly the french keyboard layout has been reworked: To prevent the issue @balbuze [described](https://github.com/volumio/volumio-plugins/pull/487#issuecomment-696292023), the "Return" and "Tab" keys have been removed, because both lead to bad "blinking" or "flickering" effects which can leave the UI hardly operable. The arrangement of the keys has been adapted according to the other layouts.