### PR TITLE
Fix for playall songs in NanoSound CD

### DIFF
--- a/plugins/music_service/nanosound_cd/index.js
+++ b/plugins/music_service/nanosound_cd/index.js
@@ -756,18 +756,7 @@ nanosoundCd.prototype.listCD=function()
 								"availableListViews": [
 									"list"
 								],
-								"items": [
-	
-									{
-										service: 'nanosound_cd',
-										type: 'song',
-										title: '[Whole CD]',
-										artist: cdmeta[0]['artist_name'],
-										album: cdmeta[0]['album_name'],
-										icon: 'fa fa-music',
-										uri: 'nanosound_cd/playall'
-									}
-								]
+								"items": []
 							}
 						]
 					}

--- a/plugins/music_service/nanosound_cd/package.json
+++ b/plugins/music_service/nanosound_cd/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nanosound_cd",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Nanosound CD playback and extraction plug-in by Nanomesher",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Using the NanoSound CD , to browse song and clicking on the song now play the right track.  