### PR TITLE
Duo

### DIFF
--- a/plugins/miscellanea/duo/index.js
+++ b/plugins/miscellanea/duo/index.js
@@ -151,7 +151,7 @@ duo.prototype.toggleDuo = function()
 	self.logger.info('[DUO] Updating system configuration...');
 	self.createDuoConfig(replacementDictionary)
 	.then(function (copySshdConfig) {
-		exec("/usr/bin/rsync --ignore-missing-args /etc/pam.d/sshd "+ __dirname +"/templates/sshd", {uid:1000, gid:1000}, function (error, stout, stderr) {
+		execSync("/usr/bin/rsync --ignore-missing-args /etc/pam.d/sshd "+ __dirname +"/templates/sshd", {uid:1000, gid:1000}, function (error, stout, stderr) {
 			if(error)
 			{
 				self.logger.error('Could not copy config file to temp location with error: ' + error);

--- a/plugins/miscellanea/duo/package.json
+++ b/plugins/miscellanea/duo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "duo",
-	"version": "1.1.5",
+	"version": "1.2.2",
 	"description": "Duo Unix with Pluggable Authentication Modules (PAM) support provides a secure and customizable method for protecting Unix and Linux logins. This plugin used a pre-compiled package for 32-bit ARM machines.",
 	"main": "index.js",
 	"scripts": {

--- a/plugins/miscellanea/duo/package.json
+++ b/plugins/miscellanea/duo/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "duo",
-	"version": "1.2.2",
-	"description": "Duo Unix with Pluggable Authentication Modules (PAM) support provides a secure and customizable method for protecting Unix and Linux logins. This plugin used a pre-compiled package for 32-bit ARM machines.",
+	"version": "1.2.3",
+	"description": "Duo Unix with Pluggable Authentication Modules (PAM) support provides a secure and customizable method for protecting Unix and Linux logins. This plugin used a pre-compiled package for 32-bit ARM and x86 machines.",
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
@balbuze & @volumio,

As per request, added x86 support (compiled and tested on my two laptops), no difference and both are working as intended. 

Test devices:
- Lenovo T60p 
- HP 6820s

I could even swap the USB stick between devices and it still worked.

Also fixed a timing issue where sometimes a bad PAM jump occurred, had to do with asynchronous actions, all critical steps are synchronous now.