### PR TITLE
Touch Display plugin: Detection of Raspberry Pi Foundation touchscreen prepared for kernel 5.x+

### DIFF
--- a/plugins/miscellanea/touch_display/package.json
+++ b/plugins/miscellanea/touch_display/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touch_display",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "The plugin enables the touch display controller for the original Raspberry 7\" touchscreen.",
 	"main": "index.js",
 	"scripts": {
@@ -18,6 +18,6 @@
 		"fs-extra": "^8.1.0",
 		"kew": "^0.7.0",
 		"v-conf": "^1.4.2",
-		"socket.io-client": "^2.3.0"
+		"socket.io-client": "^2.3.1"
 	}
 }


### PR DESCRIPTION
PR prepares the detection of a Raspberry Pi Foundation touchscreen for kernel 5.x+ which does not load the "rpi_ft5406" module anymore but the "raspberrypi_ts" module.