### PR TITLE
Touch Display plugin: Changed detection of Raspberry Pi boards in install script

### DIFF
--- a/plugins/miscellanea/touch_display/install.sh
+++ b/plugins/miscellanea/touch_display/install.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-HW=$(awk '/VOLUMIO_HARDWARE=/' /etc/*-release | sed 's/VOLUMIO_HARDWARE=//' | sed 's/\"//g')
 ID=$(awk '/VERSION_ID=/' /etc/*-release | sed 's/VERSION_ID=//' | sed 's/\"//g')
 
-if [ "$HW" = "pi" ]; then # on Raspberry Pi hardware
+if grep -q Raspberry /proc/cpuinfo; then # on Raspberry Pi hardware
   echo "Installing fake packages for kernel, bootloader and pi lib"
   wget https://repo.volumio.org/Volumio2/Binaries/arm/libraspberrypi0_0.0.1_all.deb
   wget https://repo.volumio.org/Volumio2/Binaries/arm/raspberrypi-bootloader_0.0.1_all.deb

--- a/plugins/miscellanea/touch_display/package.json
+++ b/plugins/miscellanea/touch_display/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touch_display",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "The plugin enables the touch display controller for the original Raspberry 7\" touchscreen.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
... to be independent from the value of "VOLUMIO_HARDWARE"  in /etc/os-release. This allows to install the plugin from the plugin store also on the Buster betas provided by @ashthespy ;)