### PR TITLE
IR Controller plugin: Fixed "onStop" function not resolving et al.

### DIFF
--- a/plugins/accessory/ir_controller/i18n/strings_de.json
+++ b/plugins/accessory/ir_controller/i18n/strings_de.json
@@ -11,7 +11,7 @@
     "PROFILE_SELECTOR":"Profil auswählen",
     "PROFILE_SELECTOR_DOC":"Wähle die geeignete Konfiguration für Deine Fernbedienung aus den vorhandenen Profilen aus.",
     "GPIO_CONFIGURATION":"GPIO Konfiguration",
-    "GPIO_DESC":"Das Plugin prüft nicht, ob die GPIO-Nummern in der Auswahlliste bereits für andere Zweck genutzt werden. Es ist daher sehr wichtig, vor der Auswahl einer GPIO-Nummer sicherzustellen, dass diese tatsächlich noch zur Verfügung steht.",
+    "GPIO_DESC":"Das Plugin prüft nicht, ob die GPIO-Nummern in der Auswahlliste bereits für andere Zwecke genutzt werden. Es ist daher sehr wichtig, vor der Auswahl einer GPIO-Nummer sicherzustellen, dass diese tatsächlich noch zur Verfügung steht.",
     "GPIO_IN_PIN":"GPIO des Infrarotempfängers auswählen",
     "GPIO_IN_PIN_DOC":"GPIO-Nummer, die vom Infrarotempfänger genutzt wird. HINWEIS: Hierbei handelt es sich nicht um die Nummer des physischen Pins, an den der Infrarotempfänger angeschlossen ist, sondern um die Broadcom Pinnummer (BCM), vgl. https://de.pinout.xyz/#.",
     "GPIO_PULL":"\"pull-up/-down\"-Einstellung auswählen",

--- a/plugins/accessory/ir_controller/package.json
+++ b/plugins/accessory/ir_controller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ir_controller",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Volumio IR Remote plugin",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Fixes and changes:
* index.js: Fixed "onStop" function not resolving if "lirc.service" fails to stop (this prevented the plugin from uninstalling); corrected condition in function "saveIROptions" checking for "no changes"; function "createHardwareConf" does not get called everytime a new remote configuration is saved but only on start of the plugin; simplified detection of kernel version
* i18n/strings_de.json: Fixed typo