### PR TITLE
IR Controller plugin: Added configuration for Bluesound RC1

### DIFF
--- a/plugins/accessory/ir_controller/configurations/Bluesound RC1/lircd.conf
+++ b/plugins/accessory/ir_controller/configurations/Bluesound RC1/lircd.conf
@@ -1,0 +1,55 @@
+# Please make this file available to others
+# by sending it to <lirc@bartelmus.de>
+#
+# this config file was automatically generated
+# using lirc-0.10.1-6.2~deb10u1+rpt1 on Feb 2021
+#
+# contributed by antkor
+#
+# brand: Bluesound
+# model no. of remote control: RC1
+# type of device controlled: Audio
+# devices being controlled by this remote: Bluesound player
+#
+
+begin remote
+
+  name  lircd.conf
+  bits           32
+  flags SPACE_ENC|CONST_LENGTH
+  eps            30
+  aeps          100
+
+  header       9013  4436
+  one           599  1629
+  zero          599   499
+  ptrail        598
+  repeat       9013  2178
+  gap          107978
+  toggle_bit_mask 0x0
+  frequency    38000
+
+      begin codes
+          KEY_POWER                0x61F01AE5
+          KEY_BRIGHTNESS_CYCLE     0x61F052AD
+          KEY_UP                   0x61F0827D
+          KEY_DOWN                 0x61F042BD
+          KEY_LEFT                 0x61F08A75
+          KEY_RIGHT                0x61F00AF5
+          KEY_ENTER                0x61F0E21D
+          KEY_MUTE                 0x61F0AA55
+          KEY_VOLUMEUP             0x61F0CA35
+          KEY_VOLUMEDOWN           0x61F02AD5
+          KEY_1                    0x61F0DA25
+          KEY_2                    0x61F03AC5
+          KEY_3                    0x61F0BA45
+          KEY_4                    0x61F07A85
+          KEY_5                    0x61F0FA05
+          KEY_6                    0x61F006F9
+          KEY_7                    0x61F01EE1
+          KEY_8                    0x61F09E61
+          KEY_9                    0x61F05EA1
+          KEY_0                    0x61F0DE21
+      end codes
+
+end remote

--- a/plugins/accessory/ir_controller/configurations/Bluesound RC1/lircrc
+++ b/plugins/accessory/ir_controller/configurations/Bluesound RC1/lircrc
@@ -1,0 +1,45 @@
+begin
+    prog = irexec
+    button = KEY_ENTER
+    config = /usr/local/bin/volumio toggle
+end
+begin
+    prog = irexec
+    button = KEY_RIGHT
+    config = /usr/local/bin/volumio next
+end
+begin
+    prog = irexec
+    button = KEY_LEFT
+    config = /usr/local/bin/volumio previous
+end
+begin
+    prog = irexec
+    button = KEY_UP
+    config = /usr/local/bin/volumio seek plus
+end
+begin
+    prog = irexec
+    button = KEY_DOWN
+    config = /usr/local/bin/volumio seek minus
+end
+begin
+    prog = irexec
+    button = KEY_VOLUMEUP
+    config = /usr/local/bin/volumio volume minus
+end
+begin
+    prog = irexec
+    button = KEY_VOLUMEDOWN
+    config = /usr/local/bin/volumio volume minus
+end
+begin
+    prog = irexec
+    button = KEY_MUTE
+    config = /usr/local/bin/volumio volume toggle
+end
+begin
+    prog = irexec
+    button = KEY_POWER
+    config = /sbin/shutdown -h now
+end

--- a/plugins/accessory/ir_controller/package.json
+++ b/plugins/accessory/ir_controller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ir_controller",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"description": "Volumio IR Remote plugin",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
New remote profile for the [Bluesound RC1](https://www.bluesound.com/products/rc1-remote-control/).

Thanks to forum user antkor who recorded and [provided](https://community.volumio.org/t/custom-remote-control-bluesound-rc-1/44939/3) the lircd.conf.