### PR TITLE
IR Controller plugin: Bug fix

### DIFF
--- a/plugins/accessory/ir_controller/package.json
+++ b/plugins/accessory/ir_controller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ir_controller",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "Volumio IR Remote plugin",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
PR is fixing a [bug reported on the forum](https://community.volumio.org/t/bug-with-update-1-4-0-ir-remote/45553). On Jessie based systems (i.e. Lirc 0.9.0) when using `systemctl restart lirc.service` the automatic start of irexec fails. Now using a sequence of `systemctl stop...` and `systemctl start` with a little timeout in between.