### PR TITLE
IR Controller plugin: Fix: Set "MODULES" in /etc/lirc/hardware.conf for specified devices only

### DIFF
--- a/plugins/accessory/ir_controller/UIConfig.json
+++ b/plugins/accessory/ir_controller/UIConfig.json
@@ -1,6 +1,6 @@
 {
   "page": {
-          "label": "TRANSLATE.IRCONTROLLER.IR_CONFIGURATION"
+          "label": "TRANSLATE.IRCONTROLLER.PLUGIN_CONFIGURATION"
           },
   "sections": [
                 {
@@ -49,7 +49,7 @@
                 "content": [
                              {
                              "id": "header40_gpio_in_pin",
-                             "element" : "select",
+                             "element": "select",
                              "doc": "TRANSLATE.IRCONTROLLER.GPIO_IN_PIN_DOC",
                              "label": "TRANSLATE.IRCONTROLLER.GPIO_IN_PIN",
                              "value": {},
@@ -170,7 +170,7 @@
                              },
                              {
                              "id": "header34_gpio_in_pin",
-                             "element" : "select",
+                             "element": "select",
                              "doc": "TRANSLATE.IRCONTROLLER.GPIO_IN_PIN_DOC",
                              "label": "TRANSLATE.IRCONTROLLER.GPIO_IN_PIN",
                              "value": {},
@@ -263,7 +263,7 @@
                              },
                              {
                              "id": "header26_gpio_in_pin",
-                             "element" : "select",
+                             "element": "select",
                              "doc": "TRANSLATE.IRCONTROLLER.GPIO_IN_PIN_DOC",
                              "label": "TRANSLATE.IRCONTROLLER.GPIO_IN_PIN",
                              "value": {},
@@ -340,7 +340,7 @@
                              },
                              {
                              "id": "gpio_pull",
-                             "element" : "select",
+                             "element": "select",
                              "doc": "TRANSLATE.IRCONTROLLER.GPIO_PULL_DOC",
                              "label": "TRANSLATE.IRCONTROLLER.GPIO_PULL",
                              "value": {"value": "up", "label": "TRANSLATE.IRCONTROLLER.GPIO_PULL_UP"},
@@ -368,7 +368,7 @@
                               },
                               {
                               "id": "activeState",
-                              "element" : "select",
+                              "element": "select",
                               "doc": "TRANSLATE.IRCONTROLLER.ACTIVE_STATE_DOC",
                               "label": "TRANSLATE.IRCONTROLLER.ACTIVE_STATE",
                               "visibleIf": {"field": "forceActiveState", "value": true},

--- a/plugins/accessory/ir_controller/i18n/strings_de.json
+++ b/plugins/accessory/ir_controller/i18n/strings_de.json
@@ -7,6 +7,7 @@
     "ERR_REMOVE_OVERLAY":"Fehler beim Entfernen des IR-Overlays: ",
     "ERR_GPIO_OCCUPIED":"Der ausgewählte GPIO-Eingang wird bereits benutzt.",
     "GENERIC_FAILED":"Fehlgeschlagen: ",
+    "PLUGIN_CONFIGURATION":"IR Controller Konfiguration",
     "IR_CONFIGURATION":"IR Remote Konfiguration",
     "PROFILE_SELECTOR":"Profil auswählen",
     "PROFILE_SELECTOR_DOC":"Wähle die geeignete Konfiguration für Deine Fernbedienung aus den vorhandenen Profilen aus.<br /><br />In dem Ordner \"/data/INTERNAL/ir_controller/configurations\" können benutzereigene Konfigurationen für Fernbedienungen hinterlegt werden. Hierzu ist im vorgenannten Verzeichnis für jede Fernbedienung ein Unterordner anzulegen, in dem die LIRC-Dateien \"lircrc\" und \"lirc.conf\" für die Fernbedenung gespeichert werden. Der Name des Unterordners erscheint dann in der Liste der auswählbaren Fernbedienungen. Wird dieser Name auch für eine der bereits mitgelieferten Fernbedienungskonfiguration verwendet, erhält die benutzereigene gleichnamige Konfiguration den Vorzug.<br /><br />HINWEIS: Ein Update des Plugins lässt die benutzereigenen Konfigurationen unberührt. Bei der Deinstallation des Plugins wird das Verzeichnis \"/data/INTERNAL/ir_controller\" jedoch mit allen darin enthaltenen Unterordnern und Dateien gelöscht.",

--- a/plugins/accessory/ir_controller/i18n/strings_en.json
+++ b/plugins/accessory/ir_controller/i18n/strings_en.json
@@ -7,6 +7,7 @@
     "ERR_REMOVE_OVERLAY":"Error removing IR overlay: ",
     "ERR_GPIO_OCCUPIED":"The selected GPIO input is already in use.",
     "GENERIC_FAILED":"Failed: ",
+    "PLUGIN_CONFIGURATION":"IR Controller Configuration",
     "IR_CONFIGURATION":"IR Remote Configuration",
     "PROFILE_SELECTOR":"Select profile",
     "PROFILE_SELECTOR_DOC":"Select the appropriate configuration for your remote from the available profiles.<br /><br />User-specific configurations for remote controls can be stored in the \"/data/INTERNAL/ir_controller/configurations\" folder. For this purpose, a subfolder must be created in the aforementioned directory for each remote control, in which the LIRC files \"lircrc\" and \"lirc.conf\" are stored for the remote control. The name of the subfolder appears in the list of selectable remote controls. If this name is also used for one of the remote control configurations already supplied, the user's own configuration with the same name takes precedence.<br /><br />NOTE: Updating the plugin does not affect the user-defined configurations. However, when the plugin is uninstalled, the \"/data/INTERNAL/ir_controller\" directory is deleted along with all the subfolders and files it contains.",

--- a/plugins/accessory/ir_controller/i18n/strings_fr.json
+++ b/plugins/accessory/ir_controller/i18n/strings_fr.json
@@ -7,6 +7,7 @@
     "ERR_REMOVE_OVERLAY":"Erreur en supprimant IR overlay: ",
     "ERR_GPIO_OCCUPIED":"Le GPIO est déjà utilisé.",
     "GENERIC_FAILED":"Échec: ",
+    "PLUGIN_CONFIGURATION":"Configuration de IR Controller",
     "IR_CONFIGURATION":"Configuration télécommande IR",
     "PROFILE_SELECTOR": "Choisir un modèle",
     "PROFILE_SELECTOR_DOC": "Choisissez le modèle de télécommande que vous voulez utiliser.<br /><br />Les configurations spécifiques à l'utilisateur pour les télécommandes peuvent être stockés dans le dossier \"/data/INTERNAL/ir_controller/configurations\". Pour ce faire, il faut créer dans le répertoire susmentionné un sous-dossier pour chaque télécommande, dans lequel sont stockés les fichiers LIRC \"lircrc\" et \"lirc.conf\" pour la télécommande. Le nom du sous-dossier apparaît dans la liste des télécommandes sélectionnables. Si ce nom est également utilisé pour l'une des configurations de télécommande déjà fournies, la configuration de l'utilisateur portant le même nom est prioritaire.<br /><br />NOTE : Une mise à jour du plug-in n'affecte pas les configurations définies par l'utilisateur. Cependant, lors de la désinstallation du plug-in, le répertoire \"/data/INTERNAL/ir_controller\" est supprimé avec tous les sous-dossiers et fichiers qu'il contient.",

--- a/plugins/accessory/ir_controller/i18n/strings_nl.json
+++ b/plugins/accessory/ir_controller/i18n/strings_nl.json
@@ -7,6 +7,7 @@
     "ERR_REMOVE_OVERLAY":"Fout bij het verwijderen van de IR overlay: ",
     "ERR_GPIO_OCCUPIED":"De geselecteerde GPIO-ingang is al in gebruik.",
     "GENERIC_FAILED":"Gefaald: ",
+    "PLUGIN_CONFIGURATION":"IR Controller configuratie",
     "IR_CONFIGURATION":"IR afstandsbediening configuratie",
     "PROFILE_SELECTOR":"Selecteer profiel",
     "PROFILE_SELECTOR_DOC":"Selecteer de juiste configuratie voor uw afstandsbediening uit de beschikbare profielen.<br /><br />Gebruikersspecifieke configuraties voor afstandsbedieningen kunnen worden opgeslagen in de map \"/data/INTERNAL/ir_controller/configurations\". Daartoe moet in de bovengenoemde directory voor elke afstandsbediening een submap worden aangemaakt, waarin de LIRC-bestanden \"lircrc\" en \"lirc.conf\" voor de afstandsbediening worden opgeslagen. De naam van de submap verschijnt in de lijst van selecteerbare afstandsbedieningen. Indien deze naam ook wordt gebruikt voor een van de reeds geleverde configuraties van de afstandsbediening, heeft de configuratie van de gebruiker met dezelfde naam voorrang.<br /><br />OPMERKING: Een update van de plug-in heeft geen invloed op de door de gebruiker gedefinieerde configuraties. Bij het verwijderen van de plug-in wordt echter de directory \"/data/INTERNAL/ir_controller\" verwijderd met alle submappen en bestanden die zich daarin bevinden.",

--- a/plugins/accessory/ir_controller/package.json
+++ b/plugins/accessory/ir_controller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ir_controller",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"description": "Volumio IR Remote plugin",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
With the exception of Odroid-C in the past "MODULES" in /etc/lirc/hardware.conf was assigned the value for Raspberry Pis even if the device Volumio was running on wasn't a Pi.

The PR fixes this and sets "MODULES" in /etc/lirc/hardware.conf strictly device specific (and only if it is known what setting is required for a particular device). This is currently the case for Raspberry Pis and Odroid C1, C2, C4 and N2 (lines 355-363). For all other devices "MODULES" remains unaltered.